### PR TITLE
Fix/dynamic settings

### DIFF
--- a/focusfeed/lib/core/theme/app_colors.dart
+++ b/focusfeed/lib/core/theme/app_colors.dart
@@ -32,4 +32,21 @@ class AppColors {
   static const Color cardExplainer = green;
   static const Color cardProgress = purpleLight;
   static const Color cardChallenge = redCoral;
+
+  // Onboarding / profile setup flow colors
+  // These are specific to the setup wizard screens and differ slightly
+  // from the main app dark palette to create a distinct onboarding feel.
+
+  /// Deep dark navy used as the full-screen background in the setup flow.
+  static const Color setupBackground = Color(0xFF0B0F2A);
+
+  /// Slightly lighter navy used as the card/panel surface in the setup flow.
+  static const Color setupCard = Color(0xFF151A3B);
+
+  /// Dark fill color used inside text fields and unselected chips in the setup flow.
+  static const Color setupInput = Color(0xFF0F1433);
+
+  /// Brighter purple accent used for buttons, selected chips, and active borders
+  /// in the auth and setup screens. Distinct from [purple] (#6C5CE7).
+  static const Color purpleBright = Color(0xFF855AFB);
 }

--- a/focusfeed/lib/features/auth/screens/app_entry_screen.dart
+++ b/focusfeed/lib/features/auth/screens/app_entry_screen.dart
@@ -5,6 +5,11 @@ import 'package:focusfeed/features/profile/screens/profile_setup_screen.dart';
 import 'package:focusfeed/features/profile/services/profile_service.dart';
 import 'package:focusfeed/features/nav/main_nav_screen.dart';
 
+/// Root routing widget. Decides which screen to show based on auth and
+/// profile state. Three possible outcomes:
+///   - Not logged in → WelcomeScreen
+///   - Logged in, setup incomplete → ProfileSetupScreen
+///   - Logged in, setup complete → MainNavScreen
 class AppEntryScreen extends StatelessWidget {
   const AppEntryScreen({super.key});
 
@@ -13,46 +18,53 @@ class AppEntryScreen extends StatelessWidget {
     final auth = AuthServices();
     final profileService = ProfileService();
 
+    // StreamBuilder listens to Firebase auth state in real time.
+    // Rebuilds whenever the user signs in or out.
     return StreamBuilder(
       stream: auth.authStateChanges,
       builder: (context, snapshot) {
+        // Still waiting for Firebase to confirm auth state.
         if (snapshot.connectionState == ConnectionState.waiting) {
-          return const Scaffold(
-            backgroundColor: Color(0xFF0B0F2A),
-            body: Center(
-              child: CircularProgressIndicator(
-                color: Color.fromRGBO(133, 90, 251, 1),
-              ),
-            ),
-          );
+          return const _LoadingScreen();
         }
 
+        // No authenticated user — send to login/signup.
         if (snapshot.data == null) {
           return const WelcomeScreen();
         }
 
+        // User is logged in. Check if they've finished profile setup.
         return FutureBuilder<bool>(
           future: profileService.hasCompletedSetup(),
           builder: (context, profileSnapshot) {
             if (profileSnapshot.connectionState == ConnectionState.waiting) {
-              return const Scaffold(
-                backgroundColor: Color(0xFF0B0F2A),
-                body: Center(
-                  child: CircularProgressIndicator(
-                    color: Color.fromRGBO(133, 90, 251, 1),
-                  ),
-                ),
-              );
+              return const _LoadingScreen();
             }
 
-            if (profileSnapshot.data == true) {
-              return const MainNavScreen();
-            }
-
-            return const ProfileSetupScreen();
+            // Setup complete → main app. Otherwise → setup wizard.
+            return profileSnapshot.data == true
+                ? const MainNavScreen()
+                : const ProfileSetupScreen();
           },
         );
       },
+    );
+  }
+}
+
+/// Shared full-screen loading spinner shown while waiting for Firebase.
+class _LoadingScreen extends StatelessWidget {
+  const _LoadingScreen();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      backgroundColor: Color(0xFF0B0F2A),
+      body: Center(
+        child: CircularProgressIndicator(
+          color: Color.fromRGBO(133, 90, 251, 1),
+        ),
+      ),
     );
   }
 }

--- a/focusfeed/lib/features/auth/screens/create_account_screen.dart
+++ b/focusfeed/lib/features/auth/screens/create_account_screen.dart
@@ -3,6 +3,9 @@ import 'package:focusfeed/features/auth/screens/app_entry_screen.dart';
 import 'package:focusfeed/features/auth/services/auth_service.dart';
 import 'package:focusfeed/features/profile/screens/profile_setup_screen.dart';
 
+/// Sign-up screen. Collects name, email, password, and confirm password,
+/// validates them inline, then calls [AuthServices.signUpWithEmail].
+/// On success navigates to [ProfileSetupScreen] to complete onboarding.
 class CreateAccountScreen extends StatefulWidget {
   const CreateAccountScreen({super.key});
 
@@ -163,6 +166,7 @@ class _CreateAccountScreenState extends State<CreateAccountScreen> {
                     ),
                   ),
                   onPressed: () async {
+                    // Guard against mismatched passwords before hitting Firebase.
                     if (passwordController.text !=
                         confirmPasswordController.text) {
                       debugPrint("Passwords don't match");
@@ -173,8 +177,10 @@ class _CreateAccountScreenState extends State<CreateAccountScreen> {
                       passwordController.text,
                       displayName: nameController.text,
                     );
+                    // signUpWithEmail returns null on failure — bail silently.
                     if (result == null) return;
                     if (!context.mounted) return;
+                    // Replace this screen so Back can't return to sign-up.
                     Navigator.pushReplacement(
                       context,
                       MaterialPageRoute(
@@ -227,6 +233,8 @@ class _CreateAccountScreenState extends State<CreateAccountScreen> {
                           final result = await auth.signInWithGoogle();
                           if (result == null) return;
                           if (!context.mounted) return;
+                          // Push AppEntryScreen and clear the stack — it will
+                          // re-evaluate auth + setup state and route correctly.
                           Navigator.pushAndRemoveUntil(
                             context,
                             MaterialPageRoute(
@@ -284,6 +292,8 @@ class _CreateAccountScreenState extends State<CreateAccountScreen> {
   }
 }
 
+/// Shared themed text field used across the sign-up form.
+/// Applies the app's purple border style and white text consistently.
 class _InputField extends StatelessWidget {
   final TextEditingController? controller;
   final String hint;

--- a/focusfeed/lib/features/auth/services/auth_service.dart
+++ b/focusfeed/lib/features/auth/services/auth_service.dart
@@ -3,16 +3,22 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/foundation.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 
+/// Handles all Firebase Authentication logic: email/password sign-up and
+/// sign-in, Google OAuth sign-in, sign-out, and creating the user's
+/// Firestore document on first login.
 class AuthServices {
   final FirebaseAuth auth = FirebaseAuth.instance;
   final FirebaseFirestore firestore = FirebaseFirestore.instance;
   final GoogleSignIn _googleSignIn = GoogleSignIn.instance;
 
+  /// Must be called once before using Google sign-in.
   Future<void> initGoogleSignIn() async {
     await _googleSignIn.initialize();
   }
 
-  // Sign up with email/password
+  /// Creates a new account with email and password.
+  /// Optionally sets [displayName] on the Firebase Auth profile.
+  /// Returns null if sign-up fails.
   Future<UserCredential?> signUpWithEmail(
     String email,
     String password, {
@@ -29,9 +35,10 @@ class AuthServices {
         final trimmedName = displayName?.trim();
         if (trimmedName != null && trimmedName.isNotEmpty) {
           await user.updateDisplayName(trimmedName);
+          // reload() refreshes the local user object so displayName is up to date.
           await user.reload();
         }
-
+        // Use auth.currentUser (post-reload) so the display name is included.
         await _createUserDocument(auth.currentUser ?? user);
       }
 
@@ -45,7 +52,8 @@ class AuthServices {
     }
   }
 
-  // Sign in with email/password
+  /// Signs in an existing user with email and password.
+  /// Returns null if sign-in fails.
   Future<UserCredential?> signInWithEmail(String email, String password) async {
     try {
       final credential = await auth.signInWithEmailAndPassword(
@@ -55,6 +63,8 @@ class AuthServices {
 
       final user = credential.user;
       if (user != null) {
+        // Safe to call on repeat logins — _createUserDocument is a no-op if
+        // the document already exists.
         await _createUserDocument(user);
       }
 
@@ -68,7 +78,9 @@ class AuthServices {
     }
   }
 
-  // Google Sign in
+  /// Signs in via Google OAuth. Shows the Google account picker, exchanges
+  /// the ID token for a Firebase credential, then signs into Firebase.
+  /// Returns null if the user cancels or an error occurs.
   Future<UserCredential?> signInWithGoogle() async {
     try {
       final GoogleSignInAccount googleUser = await _googleSignIn.authenticate();
@@ -83,7 +95,7 @@ class AuthServices {
       if (user != null) {
         await _createUserDocument(user);
       }
-
+      
       return userCredential;
     } on FirebaseAuthException catch (e) {
       debugPrint(e.message);
@@ -94,18 +106,24 @@ class AuthServices {
     }
   }
 
-  // Sign out
+  /// Signs out of both Google and Firebase.
+  /// Google is signed out first so its token is cleared before the Firebase
+  /// session ends.
   Future<void> signOut() async {
     await _googleSignIn.signOut();
     await auth.signOut();
   }
 
-  // Who is logged in right now?
+  /// The currently signed-in user, or null if no one is logged in.
   User? get currentUser => auth.currentUser;
 
-  // A stream that fires whenever login state changes
+  /// Stream that emits the current [User] on login and null on logout.
+  /// Also emits immediately on subscription with the persisted session state.
   Stream<User?> get authStateChanges => auth.authStateChanges();
 
+  /// Creates `users/{uid}` in Firestore the first time a user signs in.
+  /// Skips silently if the document already exists, making it safe to call
+  /// on every login.
   Future<void> _createUserDocument(User user) async {
     final userDoc = firestore.collection('users').doc(user.uid);
     final snapshot = await userDoc.get();
@@ -115,6 +133,9 @@ class AuthServices {
         'uid': user.uid,
         'email': user.email,
         'displayName': user.displayName,
+        // Lowercase copy used for case-insensitive name searches.
+        'displayNameLower': user.displayName?.toLowerCase() ?? '',
+        // Server timestamp avoids client clock drift issues.
         'createdAt': FieldValue.serverTimestamp(),
       });
     }

--- a/focusfeed/lib/features/profile/screens/profile_setup_screen.dart
+++ b/focusfeed/lib/features/profile/screens/profile_setup_screen.dart
@@ -1,9 +1,16 @@
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
+import 'package:focusfeed/core/theme/app_colors.dart';
 import 'package:focusfeed/features/auth/screens/app_entry_screen.dart';
 import 'package:focusfeed/features/auth/services/auth_service.dart';
 import 'package:focusfeed/features/profile/services/profile_service.dart';
+import 'package:focusfeed/features/profile/widgets/setup_step_school.dart';
+import 'package:focusfeed/features/profile/widgets/setup_step_courses.dart';
+import 'package:focusfeed/features/profile/widgets/setup_step_preferences.dart';
 
+/// 3-step onboarding wizard shown to new users after their first login.
+/// Collects school, courses, subjects, and app preferences, then saves
+/// them to Firestore and navigates to the main app.
 class ProfileSetupScreen extends StatefulWidget {
   const ProfileSetupScreen({super.key});
 
@@ -12,50 +19,23 @@ class ProfileSetupScreen extends StatefulWidget {
 }
 
 class _ProfileSetupScreenState extends State<ProfileSetupScreen> {
-  static const Color _bg = Color(0xFF0B0F2A);
-  static const Color _card = Color(0xFF151A3B);
-  static const Color _accent = Color.fromRGBO(133, 90, 251, 1);
-  static const Color _textPrimary = Colors.white;
-  static const Color _textSecondary = Colors.white70;
-
+  // Controllers
   final _pageController = PageController();
   final _schoolController = TextEditingController();
+
+  // Services
   final _authService = AuthServices();
   final _profileService = ProfileService();
 
-  final List<String> _availableCourses = const [
-    'Economics',
-    'Calculus',
-    'Statistics',
-    'Psychology',
-    'Accounting',
-    'Computer Science',
-    'Marketing',
-    'Biology',
-    'English',
-  ];
-
-  final List<String> _availableSubjects = const [
-    'Finance',
-    'Economics',
-    'Technology',
-    'AI',
-    'Biology',
-    'Chemistry',
-    'Physics',
-    'History',
-    'Literature',
-    'Psychology',
-    'Business',
-    'Math',
-  ];
-
+  // Wizard state
   final List<String> _selectedCourses = [];
   final List<String> _selectedSubjects = [];
-
   int _currentPage = 0;
   bool _notificationsEnabled = true;
   bool _autoGenerateFlashcards = true;
+
+  // True while the Firestore save is in flight — disables buttons and
+  // shows a spinner to prevent double-submission.
   bool _isSaving = false;
 
   @override
@@ -65,6 +45,10 @@ class _ProfileSetupScreenState extends State<ProfileSetupScreen> {
     super.dispose();
   }
 
+  // ── Navigation ─────────────────────────────────────────────────────────────
+
+  /// Validates the current page then moves forward, or triggers save on
+  /// the last page.
   void _nextPage() {
     if (_currentPage == 0 && _schoolController.text.trim().isEmpty) {
       _showMessage('Add your school to continue.');
@@ -82,11 +66,12 @@ class _ProfileSetupScreenState extends State<ProfileSetupScreen> {
     );
   }
 
-  Future<void> _saveSetup() async {
-    if (_isSaving) {
-      return;
-    }
+  // ── Async operations ────────────────────────────────────────────────────────
 
+  /// Saves all setup data to Firestore then navigates to the main app.
+  /// Clears _isSaving in a finally block so the spinner always goes away.
+  Future<void> _saveSetup() async {
+    if (_isSaving) return;
     setState(() => _isSaving = true);
 
     try {
@@ -98,41 +83,31 @@ class _ProfileSetupScreenState extends State<ProfileSetupScreen> {
         autoGenerateFlashcards: _autoGenerateFlashcards,
       );
 
-      if (!mounted) {
-        return;
-      }
+      if (!mounted) return;
 
+      // Remove all routes so the user can't press Back into the wizard.
       Navigator.pushNamedAndRemoveUntil(context, '/home', (_) => false);
     } on FirebaseException catch (e) {
-      if (e.code == 'permission-denied') {
-        _showMessage(
-          'Firestore blocked the save. Publish rules that allow users to write their own profile.',
-        );
-      } else {
-        _showMessage('Save failed: ${e.code}');
-      }
+      _showMessage(e.code == 'permission-denied'
+          ? 'Firestore blocked the save. Check your security rules.'
+          : 'Save failed: ${e.code}');
     } catch (e) {
       _showMessage('Could not save your setup. ${e.runtimeType}');
     } finally {
-      if (mounted) {
-        setState(() => _isSaving = false);
-      }
+      if (mounted) setState(() => _isSaving = false);
     }
   }
 
+  /// Signs the user out and returns them to AppEntryScreen.
+  /// Blocked while a save is in progress.
   Future<void> _logout() async {
-    if (_isSaving) {
-      return;
-    }
-
+    if (_isSaving) return;
     try {
       await _authService.signOut();
-      if (!mounted) {
-        return;
-      }
+      if (!mounted) return;
       Navigator.pushAndRemoveUntil(
         context,
-        MaterialPageRoute(builder: (context) => const AppEntryScreen()),
+        MaterialPageRoute(builder: (_) => const AppEntryScreen()),
         (_) => false,
       );
     } catch (_) {
@@ -140,60 +115,58 @@ class _ProfileSetupScreenState extends State<ProfileSetupScreen> {
     }
   }
 
+  // ── Helpers ─────────────────────────────────────────────────────────────────
+
+  /// Adds [value] to [selections] if absent, removes it if present.
   void _toggleSelection(List<String> selections, String value) {
     setState(() {
-      if (selections.contains(value)) {
-        selections.remove(value);
-      } else {
-        selections.add(value);
-      }
+      selections.contains(value)
+          ? selections.remove(value)
+          : selections.add(value);
     });
   }
 
   void _showMessage(String message) {
-    ScaffoldMessenger.of(
-      context,
-    ).showSnackBar(SnackBar(content: Text(message)));
+    ScaffoldMessenger.of(context)
+        .showSnackBar(SnackBar(content: Text(message)));
   }
+
+  // ── Build ───────────────────────────────────────────────────────────────────
 
   @override
   Widget build(BuildContext context) {
-    final user = FirebaseAuth.instance.currentUser;
-    final rawDisplayName = user?.displayName?.trim();
-    final displayName = rawDisplayName != null && rawDisplayName.isNotEmpty
-        ? rawDisplayName
-        : 'there';
+    final rawName = FirebaseAuth.instance.currentUser?.displayName?.trim();
+    final displayName = (rawName?.isNotEmpty ?? false) ? rawName! : 'there';
 
     return Scaffold(
-      backgroundColor: _bg,
+      backgroundColor: AppColors.setupBackground,
       body: SafeArea(
         child: Padding(
           padding: const EdgeInsets.all(24),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
+              // Log out button — top right
               Align(
                 alignment: Alignment.centerRight,
                 child: TextButton.icon(
                   onPressed: _logout,
-                  icon: const Icon(
-                    Icons.logout,
-                    color: _textSecondary,
-                    size: 18,
-                  ),
+                  icon: const Icon(Icons.logout, color: Colors.white70, size: 18),
                   label: const Text(
                     'Log Out',
                     style: TextStyle(
-                      color: _textSecondary,
+                      color: Colors.white70,
                       fontWeight: FontWeight.w600,
                     ),
                   ),
                 ),
               ),
+
+              // Greeting
               Text(
                 'Welcome, $displayName',
                 style: const TextStyle(
-                  color: _textPrimary,
+                  color: Colors.white,
                   fontSize: 30,
                   fontWeight: FontWeight.bold,
                 ),
@@ -201,25 +174,30 @@ class _ProfileSetupScreenState extends State<ProfileSetupScreen> {
               const SizedBox(height: 8),
               const Text(
                 'Set up your study feed in a few quick steps.',
-                style: TextStyle(color: _textSecondary, fontSize: 15),
+                style: TextStyle(color: Colors.white70, fontSize: 15),
               ),
               const SizedBox(height: 20),
+
+              // Step progress bar — filled segments show completed/current steps
               Row(
-                children: List.generate(
-                  3,
-                  (index) => Expanded(
+                children: List.generate(3, (index) {
+                  return Expanded(
                     child: Container(
                       height: 6,
                       margin: EdgeInsets.only(right: index == 2 ? 0 : 8),
                       decoration: BoxDecoration(
-                        color: index <= _currentPage ? _accent : Colors.white12,
+                        color: index <= _currentPage
+                            ? AppColors.purpleBright
+                            : Colors.white12,
                         borderRadius: BorderRadius.circular(999),
                       ),
                     ),
-                  ),
-                ),
+                  );
+                }),
               ),
               const SizedBox(height: 24),
+
+              // Page content — swipe disabled so buttons enforce validation
               Expanded(
                 child: PageView(
                   controller: _pageController,
@@ -227,66 +205,32 @@ class _ProfileSetupScreenState extends State<ProfileSetupScreen> {
                   onPageChanged: (value) =>
                       setState(() => _currentPage = value),
                   children: [
-                    _SetupCard(
-                      title: 'Where are you studying?',
-                      subtitle:
-                          'This helps us personalize the profile you build next.',
-                      child: _ThemedTextField(
-                        controller: _schoolController,
-                        label: 'School',
-                        icon: Icons.school_outlined,
-                      ),
+                    SetupStepSchool(controller: _schoolController),
+                    SetupStepCourses(
+                      selectedCourses: _selectedCourses,
+                      onTap: (v) => _toggleSelection(_selectedCourses, v),
                     ),
-                    _SetupCard(
-                      title: 'Pick your courses',
-                      subtitle:
-                          'Choose the classes you want FocusFeed to prioritize.',
-                      child: _ChoiceWrap(
-                        options: _availableCourses,
-                        selections: _selectedCourses,
-                        onTap: (value) =>
-                            _toggleSelection(_selectedCourses, value),
-                      ),
-                    ),
-                    _SetupCard(
-                      title: 'Finish your preferences',
-                      subtitle: 'Select topics and a couple of app defaults.',
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          _ChoiceWrap(
-                            options: _availableSubjects,
-                            selections: _selectedSubjects,
-                            onTap: (value) =>
-                                _toggleSelection(_selectedSubjects, value),
-                          ),
-                          const SizedBox(height: 18),
-                          _PreferenceSwitch(
-                            title: 'Notifications',
-                            subtitle: 'Enable reminders and updates',
-                            value: _notificationsEnabled,
-                            onChanged: (value) =>
-                                setState(() => _notificationsEnabled = value),
-                          ),
-                          const SizedBox(height: 12),
-                          _PreferenceSwitch(
-                            title: 'Auto-generate flashcards',
-                            subtitle:
-                                'Create flashcards from imported study content',
-                            value: _autoGenerateFlashcards,
-                            onChanged: (value) =>
-                                setState(() => _autoGenerateFlashcards = value),
-                          ),
-                        ],
-                      ),
+                    SetupStepPreferences(
+                      selectedSubjects: _selectedSubjects,
+                      onSubjectTap: (v) =>
+                          _toggleSelection(_selectedSubjects, v),
+                      notificationsEnabled: _notificationsEnabled,
+                      onNotificationsChanged: (v) =>
+                          setState(() => _notificationsEnabled = v),
+                      autoGenerateFlashcards: _autoGenerateFlashcards,
+                      onAutoGenerateChanged: (v) =>
+                          setState(() => _autoGenerateFlashcards = v),
                     ),
                   ],
                 ),
               ),
               const SizedBox(height: 20),
+
+              // Navigation buttons
               Row(
                 children: [
-                  if (_currentPage > 0)
+                  // Back button — hidden on the first page
+                  if (_currentPage > 0) ...[
                     Expanded(
                       child: OutlinedButton(
                         style: OutlinedButton.styleFrom(
@@ -298,23 +242,24 @@ class _ProfileSetupScreenState extends State<ProfileSetupScreen> {
                         ),
                         onPressed: _isSaving
                             ? null
-                            : () {
-                                _pageController.previousPage(
+                            : () => _pageController.previousPage(
                                   duration: const Duration(milliseconds: 220),
                                   curve: Curves.easeOut,
-                                );
-                              },
+                                ),
                         child: const Text(
                           'Back',
-                          style: TextStyle(color: _textPrimary),
+                          style: TextStyle(color: Colors.white),
                         ),
                       ),
                     ),
-                  if (_currentPage > 0) const SizedBox(width: 12),
+                    const SizedBox(width: 12),
+                  ],
+
+                  // Continue / Finish Setup button
                   Expanded(
                     child: ElevatedButton(
                       style: ElevatedButton.styleFrom(
-                        backgroundColor: _accent,
+                        backgroundColor: AppColors.purpleBright,
                         minimumSize: const Size.fromHeight(52),
                         shape: RoundedRectangleBorder(
                           borderRadius: BorderRadius.circular(14),
@@ -344,195 +289,6 @@ class _ProfileSetupScreenState extends State<ProfileSetupScreen> {
             ],
           ),
         ),
-      ),
-    );
-  }
-}
-
-class _SetupCard extends StatelessWidget {
-  const _SetupCard({
-    required this.title,
-    required this.subtitle,
-    required this.child,
-  });
-
-  final String title;
-  final String subtitle;
-  final Widget child;
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.all(20),
-      decoration: BoxDecoration(
-        color: _ProfileSetupScreenState._card,
-        borderRadius: BorderRadius.circular(20),
-        border: Border.all(color: Colors.white10),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            title,
-            style: const TextStyle(
-              color: _ProfileSetupScreenState._textPrimary,
-              fontSize: 22,
-              fontWeight: FontWeight.bold,
-            ),
-          ),
-          const SizedBox(height: 8),
-          Text(
-            subtitle,
-            style: const TextStyle(
-              color: _ProfileSetupScreenState._textSecondary,
-              fontSize: 14,
-              height: 1.4,
-            ),
-          ),
-          const SizedBox(height: 20),
-          Expanded(child: SingleChildScrollView(child: child)),
-        ],
-      ),
-    );
-  }
-}
-
-class _ThemedTextField extends StatelessWidget {
-  const _ThemedTextField({
-    required this.controller,
-    required this.label,
-    required this.icon,
-  });
-
-  final TextEditingController controller;
-  final String label;
-  final IconData icon;
-
-  @override
-  Widget build(BuildContext context) {
-    return TextField(
-      controller: controller,
-      style: const TextStyle(color: _ProfileSetupScreenState._textPrimary),
-      decoration: InputDecoration(
-        labelText: label,
-        labelStyle: const TextStyle(
-          color: _ProfileSetupScreenState._textSecondary,
-        ),
-        prefixIcon: Icon(icon, color: _ProfileSetupScreenState._textSecondary),
-        filled: true,
-        fillColor: const Color(0xFF0F1433),
-        enabledBorder: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(14),
-          borderSide: const BorderSide(color: Colors.white10),
-        ),
-        focusedBorder: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(14),
-          borderSide: const BorderSide(
-            color: _ProfileSetupScreenState._accent,
-            width: 1.4,
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-class _ChoiceWrap extends StatelessWidget {
-  const _ChoiceWrap({
-    required this.options,
-    required this.selections,
-    required this.onTap,
-  });
-
-  final List<String> options;
-  final List<String> selections;
-  final ValueChanged<String> onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    return Wrap(
-      spacing: 10,
-      runSpacing: 10,
-      children: options.map((option) {
-        final isSelected = selections.contains(option);
-
-        return ChoiceChip(
-          label: Text(option),
-          selected: isSelected,
-          onSelected: (_) => onTap(option),
-          selectedColor: _ProfileSetupScreenState._accent,
-          backgroundColor: const Color(0xFF0F1433),
-          side: BorderSide(
-            color: isSelected
-                ? _ProfileSetupScreenState._accent
-                : Colors.white10,
-          ),
-          labelStyle: TextStyle(
-            color: isSelected ? Colors.white : Colors.white70,
-            fontWeight: FontWeight.w600,
-          ),
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(12),
-          ),
-        );
-      }).toList(),
-    );
-  }
-}
-
-class _PreferenceSwitch extends StatelessWidget {
-  const _PreferenceSwitch({
-    required this.title,
-    required this.subtitle,
-    required this.value,
-    required this.onChanged,
-  });
-
-  final String title;
-  final String subtitle;
-  final bool value;
-  final ValueChanged<bool> onChanged;
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
-      decoration: BoxDecoration(
-        color: const Color(0xFF0F1433),
-        borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: Colors.white10),
-      ),
-      child: Row(
-        children: [
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  title,
-                  style: const TextStyle(
-                    color: _ProfileSetupScreenState._textPrimary,
-                    fontWeight: FontWeight.w600,
-                    fontSize: 15,
-                  ),
-                ),
-                const SizedBox(height: 4),
-                Text(
-                  subtitle,
-                  style: const TextStyle(
-                    color: _ProfileSetupScreenState._textSecondary,
-                    fontSize: 13,
-                  ),
-                ),
-              ],
-            ),
-          ),
-          Switch(
-            value: value,
-            activeThumbColor: _ProfileSetupScreenState._accent,
-            onChanged: onChanged,
-          ),
-        ],
       ),
     );
   }

--- a/focusfeed/lib/features/profile/services/profile_service.dart
+++ b/focusfeed/lib/features/profile/services/profile_service.dart
@@ -1,6 +1,8 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 
+/// Handles Firestore reads and writes for the user's profile document.
+/// Supports dependency injection so Firebase can be mocked in tests.
 class ProfileService {
   ProfileService({FirebaseFirestore? firestore, FirebaseAuth? auth})
     : _firestore = firestore ?? FirebaseFirestore.instance,
@@ -9,27 +11,27 @@ class ProfileService {
   final FirebaseFirestore _firestore;
   final FirebaseAuth _auth;
 
+  /// Returns the signed-in user, or throws [StateError] if no one is logged in.
   User get _currentUser {
     final user = _auth.currentUser;
-    if (user == null) {
-      throw StateError('No authenticated user found.');
-    }
+    if (user == null) throw StateError('No authenticated user found.');
     return user;
   }
 
+  /// Reference to `users/{uid}` — always reflects the current user's UID.
   DocumentReference<Map<String, dynamic>> get _profileDoc =>
       _firestore.collection('users').doc(_currentUser.uid);
 
+  /// Returns true if the user's Firestore document has `setupComplete: true`.
+  /// Returns false if the document doesn't exist or the field is missing/false.
   Future<bool> hasCompletedSetup() async {
     final snapshot = await _profileDoc.get();
-    if (!snapshot.exists) {
-      return false;
-    }
-
-    final data = snapshot.data();
-    return data?['setupComplete'] == true;
+    if (!snapshot.exists) return false;
+    return snapshot.data()?['setupComplete'] == true;
   }
 
+  /// Writes the user's onboarding choices to Firestore and marks setup complete.
+  /// Uses merge:true so existing fields (like uid, createdAt) are not overwritten.
   Future<void> saveSetup({
     required String school,
     required List<String> selectedCourses,

--- a/focusfeed/lib/features/profile/services/profile_service.dart
+++ b/focusfeed/lib/features/profile/services/profile_service.dart
@@ -22,8 +22,28 @@ class ProfileService {
   DocumentReference<Map<String, dynamic>> get _profileDoc =>
       _firestore.collection('users').doc(_currentUser.uid);
 
-  /// Returns true if the user's Firestore document has `setupComplete: true`.
-  /// Returns false if the document doesn't exist or the field is missing/false.
+  /// Returns the full `users/{uid}` document as a raw map, or `null` if the
+  /// document does not exist (e.g. the user was created before Firestore
+  /// writes were added).
+  Future<Map<String, dynamic>?> getProfile() async {
+    final snapshot = await _profileDoc.get();
+    if (!snapshot.exists) return null;
+    return snapshot.data();
+  }
+
+  /// Merges [data] into `users/{uid}` without overwriting unrelated fields.
+  /// Always stamps `updatedAt` with a server timestamp so the last-modified
+  /// time is always accurate regardless of client clock drift.
+  Future<void> updateProfile(Map<String, dynamic> data) async {
+    await _profileDoc.set(
+      {...data, 'updatedAt': FieldValue.serverTimestamp()},
+      SetOptions(merge: true),
+    );
+  }
+
+  /// Returns `true` if `users/{uid}` has `setupComplete == true`.
+  /// Used by [AppEntryScreen] to decide whether to show the onboarding wizard
+  /// or the main app on login.
   Future<bool> hasCompletedSetup() async {
     final snapshot = await _profileDoc.get();
     if (!snapshot.exists) return false;

--- a/focusfeed/lib/features/profile/widgets/choice_wrap.dart
+++ b/focusfeed/lib/features/profile/widgets/choice_wrap.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:focusfeed/core/theme/app_colors.dart';
+
+/// Flow-layout grid of selectable chips.
+/// Selected chips are highlighted purple. Tapping any chip calls [onTap]
+/// with the chip's value — the parent owns and updates [selections].
+class ChoiceWrap extends StatelessWidget {
+  const ChoiceWrap({
+    super.key,
+    required this.options,
+    required this.selections,
+    required this.onTap,
+  });
+
+  final List<String> options;
+  final List<String> selections;
+  final ValueChanged<String> onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      spacing: 10,
+      runSpacing: 10,
+      children: options.map((option) {
+        final isSelected = selections.contains(option);
+        return ChoiceChip(
+          label: Text(option),
+          selected: isSelected,
+          // Discard the bool argument — we manage toggle state in the parent.
+          onSelected: (_) => onTap(option),
+          selectedColor: AppColors.purpleBright,
+          backgroundColor: AppColors.setupInput,
+          side: BorderSide(
+            color: isSelected ? AppColors.purpleBright : Colors.white10,
+          ),
+          labelStyle: TextStyle(
+            color: isSelected ? Colors.white : Colors.white70,
+            fontWeight: FontWeight.w600,
+          ),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(12),
+          ),
+        );
+      }).toList(),
+    );
+  }
+}

--- a/focusfeed/lib/features/profile/widgets/preference_switch.dart
+++ b/focusfeed/lib/features/profile/widgets/preference_switch.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import 'package:focusfeed/core/theme/app_colors.dart';
+
+/// A labeled toggle row with a [title], [subtitle], and a [Switch].
+/// The parent owns the boolean state and passes it in via [value] and [onChanged].
+class PreferenceSwitch extends StatelessWidget {
+  const PreferenceSwitch({
+    super.key,
+    required this.title,
+    required this.subtitle,
+    required this.value,
+    required this.onChanged,
+  });
+
+  final String title;
+  final String subtitle;
+  final bool value;
+  final ValueChanged<bool> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+      decoration: BoxDecoration(
+        color: AppColors.setupInput,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: Colors.white10),
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontWeight: FontWeight.w600,
+                    fontSize: 15,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  subtitle,
+                  style: const TextStyle(color: Colors.white70, fontSize: 13),
+                ),
+              ],
+            ),
+          ),
+          Switch(
+            value: value,
+            activeThumbColor: AppColors.purpleBright,
+            onChanged: onChanged,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/focusfeed/lib/features/profile/widgets/setup_card.dart
+++ b/focusfeed/lib/features/profile/widgets/setup_card.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:focusfeed/core/theme/app_colors.dart';
+
+/// Dark rounded card container used on every page of the setup wizard.
+/// Renders a [title], [subtitle], and a scrollable [child] content area.
+class SetupCard extends StatelessWidget {
+  const SetupCard({
+    super.key,
+    required this.title,
+    required this.subtitle,
+    required this.child,
+  });
+
+  final String title;
+  final String subtitle;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: AppColors.setupCard,
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(color: Colors.white10),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: const TextStyle(
+              color: Colors.white,
+              fontSize: 22,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            subtitle,
+            style: const TextStyle(
+              color: Colors.white70,
+              fontSize: 14,
+              height: 1.4,
+            ),
+          ),
+          const SizedBox(height: 20),
+          // Expanded + SingleChildScrollView lets the content grow and
+          // scroll without overflowing the card on smaller screens.
+          Expanded(child: SingleChildScrollView(child: child)),
+        ],
+      ),
+    );
+  }
+}

--- a/focusfeed/lib/features/profile/widgets/setup_step_courses.dart
+++ b/focusfeed/lib/features/profile/widgets/setup_step_courses.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:focusfeed/features/profile/widgets/setup_card.dart';
+import 'package:focusfeed/features/profile/widgets/choice_wrap.dart';
+
+/// Setup wizard page 1 — lets the user pick which courses to prioritize.
+class SetupStepCourses extends StatelessWidget {
+  const SetupStepCourses({
+    super.key,
+    required this.selectedCourses,
+    required this.onTap,
+  });
+
+  static const List<String> availableCourses = [
+    'Economics',
+    'Calculus',
+    'Statistics',
+    'Psychology',
+    'Accounting',
+    'Computer Science',
+    'Marketing',
+    'Biology',
+    'English',
+  ];
+
+  final List<String> selectedCourses;
+  final ValueChanged<String> onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return SetupCard(
+      title: 'Pick your courses',
+      subtitle: 'Choose the classes you want FocusFeed to prioritize.',
+      child: ChoiceWrap(
+        options: availableCourses,
+        selections: selectedCourses,
+        onTap: onTap,
+      ),
+    );
+  }
+}

--- a/focusfeed/lib/features/profile/widgets/setup_step_preferences.dart
+++ b/focusfeed/lib/features/profile/widgets/setup_step_preferences.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:focusfeed/features/profile/widgets/setup_card.dart';
+import 'package:focusfeed/features/profile/widgets/choice_wrap.dart';
+import 'package:focusfeed/features/profile/widgets/preference_switch.dart';
+
+/// Setup wizard page 2 — subject interests and app preference toggles.
+class SetupStepPreferences extends StatelessWidget {
+  const SetupStepPreferences({
+    super.key,
+    required this.selectedSubjects,
+    required this.onSubjectTap,
+    required this.notificationsEnabled,
+    required this.onNotificationsChanged,
+    required this.autoGenerateFlashcards,
+    required this.onAutoGenerateChanged,
+  });
+
+  static const List<String> availableSubjects = [
+    'Finance',
+    'Economics',
+    'Technology',
+    'AI',
+    'Biology',
+    'Chemistry',
+    'Physics',
+    'History',
+    'Literature',
+    'Psychology',
+    'Business',
+    'Math',
+  ];
+
+  final List<String> selectedSubjects;
+  final ValueChanged<String> onSubjectTap;
+  final bool notificationsEnabled;
+  final ValueChanged<bool> onNotificationsChanged;
+  final bool autoGenerateFlashcards;
+  final ValueChanged<bool> onAutoGenerateChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return SetupCard(
+      title: 'Finish your preferences',
+      subtitle: 'Select topics and a couple of app defaults.',
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          ChoiceWrap(
+            options: availableSubjects,
+            selections: selectedSubjects,
+            onTap: onSubjectTap,
+          ),
+          const SizedBox(height: 18),
+          PreferenceSwitch(
+            title: 'Notifications',
+            subtitle: 'Enable reminders and updates',
+            value: notificationsEnabled,
+            onChanged: onNotificationsChanged,
+          ),
+          const SizedBox(height: 12),
+          PreferenceSwitch(
+            title: 'Auto-generate flashcards',
+            subtitle: 'Create flashcards from imported study content',
+            value: autoGenerateFlashcards,
+            onChanged: onAutoGenerateChanged,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/focusfeed/lib/features/profile/widgets/setup_step_school.dart
+++ b/focusfeed/lib/features/profile/widgets/setup_step_school.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'package:focusfeed/features/profile/widgets/setup_card.dart';
+import 'package:focusfeed/features/profile/widgets/themed_text_field.dart';
+
+/// Setup wizard page 0 — asks the user which school they attend.
+/// The [controller] is owned by the parent so it can read the value
+/// during validation and save.
+class SetupStepSchool extends StatelessWidget {
+  const SetupStepSchool({super.key, required this.controller});
+
+  final TextEditingController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return SetupCard(
+      title: 'Where are you studying?',
+      subtitle: 'This helps us personalize the profile you build next.',
+      child: ThemedTextField(
+        controller: controller,
+        label: 'School',
+        icon: Icons.school_outlined,
+      ),
+    );
+  }
+}

--- a/focusfeed/lib/features/profile/widgets/themed_text_field.dart
+++ b/focusfeed/lib/features/profile/widgets/themed_text_field.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:focusfeed/core/theme/app_colors.dart';
+
+/// Dark-styled text field for use in the setup wizard.
+/// Shows a white70 label and prefix [icon], with a purple border on focus.
+class ThemedTextField extends StatelessWidget {
+  const ThemedTextField({
+    super.key,
+    required this.controller,
+    required this.label,
+    required this.icon,
+  });
+
+  final TextEditingController controller;
+  final String label;
+  final IconData icon;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+      controller: controller,
+      style: const TextStyle(color: Colors.white),
+      decoration: InputDecoration(
+        labelText: label,
+        labelStyle: const TextStyle(color: Colors.white70),
+        prefixIcon: Icon(icon, color: Colors.white70),
+        filled: true,
+        fillColor: AppColors.setupInput,
+        enabledBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(14),
+          borderSide: const BorderSide(color: Colors.white10),
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(14),
+          borderSide: const BorderSide(color: AppColors.purpleBright, width: 1.4),
+        ),
+      ),
+    );
+  }
+}

--- a/focusfeed/lib/features/settings/settings_screen.dart
+++ b/focusfeed/lib/features/settings/settings_screen.dart
@@ -1,8 +1,12 @@
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:focusfeed/features/auth/services/auth_service.dart';
+import 'package:focusfeed/features/profile/services/profile_service.dart';
 import 'settings_modals.dart';
 import 'settings_widgets.dart';
 
+/// Settings screen — displays and edits the current user's account details,
+/// academic preferences, and app preferences.
 class SettingsScreen extends StatefulWidget {
   const SettingsScreen({super.key});
 
@@ -11,16 +15,63 @@ class SettingsScreen extends StatefulWidget {
 }
 
 class _SettingsScreenState extends State<SettingsScreen> {
-  String username = "Cardini Panini";
-  String email = "Cardini@gmail.com";
-  String passwordMasked = "••••••••";
-  String school = "Louisiana State University";
+  final _profileService = ProfileService();
+  final _auth = AuthServices();
 
-  List<String> selectedCourses = ["Computer Science"];
-  List<String> selectedSubjects = ["AI", "Technology"];
+  /// True while the initial Firestore read is in flight. Shows a spinner
+  /// instead of the ListView so stale placeholder values are never visible.
+  bool _isLoading = true;
 
+  // Account fields
+  String username = "";
+  String email = "";
+  String school = "";
+
+  // Academic preference fields
+  List<String> selectedCourses = [];
+  List<String> selectedSubjects = [];
+
+  // App preference fields
   bool notificationsEnabled = true;
   bool autoGenerateFlashcards = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadProfile();
+  }
+
+  /// Reads the user's Firestore document and populates local state.
+  ///
+  /// Falls back to [FirebaseAuth.currentUser] fields if the Firestore doc is
+  /// missing a value (e.g. the user signed in via Google before completing
+  /// profile setup). On any error, clears [_isLoading] so the screen still
+  /// renders rather than spinning forever.
+  Future<void> _loadProfile() async {
+    try {
+      final data = await _profileService.getProfile();
+      final firebaseUser = FirebaseAuth.instance.currentUser;
+      if (!mounted) return;
+      setState(() {
+        username = data?['displayName'] as String? ??
+            firebaseUser?.displayName ??
+            '';
+        email = data?['email'] as String? ?? firebaseUser?.email ?? '';
+        school = data?['school'] as String? ?? '';
+        selectedCourses =
+            List<String>.from(data?['selectedCourses'] as List? ?? []);
+        selectedSubjects =
+            List<String>.from(data?['selectedSubjects'] as List? ?? []);
+        notificationsEnabled =
+            data?['notificationsEnabled'] as bool? ?? true;
+        autoGenerateFlashcards =
+            data?['autoGenerateFlashcards'] as bool? ?? true;
+        _isLoading = false;
+      });
+    } catch (_) {
+      if (mounted) setState(() => _isLoading = false);
+    }
+  }
 
   final List<String> availableCourses = [
     "Economics",
@@ -65,7 +116,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
         title: const Text('Settings', style: TextStyle(color: _textPrimary)),
         iconTheme: const IconThemeData(color: _textPrimary),
       ),
-      body: ListView(
+      body: _isLoading
+          ? const Center(child: CircularProgressIndicator())
+          : ListView(
         padding: const EdgeInsets.all(16),
         children: [
           const SettingsSectionTitle(title: "Account", textColor: _textPrimary),
@@ -154,10 +207,12 @@ class _SettingsScreenState extends State<SettingsScreen> {
             title: "Notifications",
             subtitle: "Enable reminders and updates",
             value: notificationsEnabled,
+            // Update local state immediately for instant feedback, then
+            // persist to Firestore without awaiting — a failed write here
+            // is not worth blocking the toggle animation for.
             onChanged: (value) {
-              setState(() {
-                notificationsEnabled = value;
-              });
+              setState(() => notificationsEnabled = value);
+              _profileService.updateProfile({'notificationsEnabled': value});
               _showSnackBar(
                 value ? "Notifications enabled" : "Notifications disabled",
               );
@@ -172,10 +227,10 @@ class _SettingsScreenState extends State<SettingsScreen> {
             title: "Auto-generate flashcards",
             subtitle: "Create flashcards from imported study content",
             value: autoGenerateFlashcards,
+            // Same fire-and-forget pattern as the notifications toggle above.
             onChanged: (value) {
-              setState(() {
-                autoGenerateFlashcards = value;
-              });
+              setState(() => autoGenerateFlashcards = value);
+              _profileService.updateProfile({'autoGenerateFlashcards': value});
               _showSnackBar(
                 value
                     ? "Auto-generate flashcards enabled"
@@ -243,6 +298,11 @@ class _SettingsScreenState extends State<SettingsScreen> {
     );
   }
 
+  // Dialog
+
+  /// Updates the display name in both Firebase Auth and Firestore so both
+  /// sources stay in sync. Firebase Auth is the source of truth for the
+  /// logged-in user object; Firestore is queried by other features.
   void _openUsernameDialog() {
     final controller = TextEditingController(text: username);
 
@@ -261,15 +321,21 @@ class _SettingsScreenState extends State<SettingsScreen> {
           const SizedBox(height: 20),
           _primaryButton(
             label: "Save",
-            onPressed: () {
-              if (controller.text.trim().isEmpty) return;
+            onPressed: () async {
+              final value = controller.text.trim();
+              if (value.isEmpty) return;
 
-              setState(() {
-                username = controller.text.trim();
-              });
-
-              Navigator.pop(context);
-              _showSnackBar("Username updated");
+              try {
+                await FirebaseAuth.instance.currentUser
+                    ?.updateDisplayName(value);
+                await _profileService.updateProfile({'displayName': value});
+                if (!mounted) return;
+                setState(() => username = value);
+                Navigator.pop(context);
+                _showSnackBar("Username updated");
+              } catch (_) {
+                _showSnackBar("Failed to update username");
+              }
             },
           ),
         ],
@@ -277,6 +343,10 @@ class _SettingsScreenState extends State<SettingsScreen> {
     );
   }
 
+  /// Sends a verification email to the new address via [verifyBeforeUpdateEmail].
+  /// Firebase Auth only swaps the email after the user clicks the link, so the
+  /// Auth object still holds the old email until then. Firestore is updated
+  /// optimistically so the UI reflects the intended new value immediately.
   void _openEmailDialog() {
     final controller = TextEditingController(text: email);
 
@@ -296,20 +366,29 @@ class _SettingsScreenState extends State<SettingsScreen> {
           const SizedBox(height: 20),
           _primaryButton(
             label: "Save",
-            onPressed: () {
+            onPressed: () async {
               final value = controller.text.trim();
-
               if (!value.contains("@")) {
                 _showSnackBar("Invalid email");
                 return;
               }
 
-              setState(() {
-                email = value;
-              });
-
-              Navigator.pop(context);
-              _showSnackBar("Email updated");
+              try {
+                await FirebaseAuth.instance.currentUser
+                    ?.verifyBeforeUpdateEmail(value);
+                await _profileService.updateProfile({'email': value});
+                if (!mounted) return;
+                setState(() => email = value);
+                Navigator.pop(context);
+                _showSnackBar(
+                    "Verification email sent. Email updates after confirmation.");
+              } on FirebaseAuthException catch (e) {
+                _showSnackBar(e.code == 'requires-recent-login'
+                    ? 'Please log out and log back in before changing your email.'
+                    : 'Failed to update email: ${e.message}');
+              } catch (_) {
+                _showSnackBar("Failed to update email");
+              }
             },
           ),
         ],
@@ -317,6 +396,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
     );
   }
 
+  /// Re-authenticates the user with their current password before calling
+  /// [updatePassword]. Firebase requires re-authentication for sensitive
+  /// operations when the session was established too long ago.
   void _openPasswordDialog() {
     final current = TextEditingController();
     final newPass = TextEditingController();
@@ -352,14 +434,37 @@ class _SettingsScreenState extends State<SettingsScreen> {
           const SizedBox(height: 20),
           _primaryButton(
             label: "Save",
-            onPressed: () {
+            onPressed: () async {
               if (newPass.text != confirm.text) {
                 _showSnackBar("Passwords do not match");
                 return;
               }
+              if (newPass.text.length < 6) {
+                _showSnackBar("Password must be at least 6 characters");
+                return;
+              }
 
-              Navigator.pop(context);
-              _showSnackBar("Password updated");
+              try {
+                final user = FirebaseAuth.instance.currentUser;
+                if (user?.email != null) {
+                  final cred = EmailAuthProvider.credential(
+                    email: user!.email!,
+                    password: current.text,
+                  );
+                  await user.reauthenticateWithCredential(cred);
+                }
+                await FirebaseAuth.instance.currentUser
+                    ?.updatePassword(newPass.text);
+                if (!mounted) return;
+                Navigator.pop(context);
+                _showSnackBar("Password updated");
+              } on FirebaseAuthException catch (e) {
+                _showSnackBar(e.code == 'wrong-password'
+                    ? 'Current password is incorrect.'
+                    : 'Failed to update password: ${e.message}');
+              } catch (_) {
+                _showSnackBar("Failed to update password");
+              }
             },
           ),
         ],
@@ -385,13 +490,17 @@ class _SettingsScreenState extends State<SettingsScreen> {
           const SizedBox(height: 20),
           _primaryButton(
             label: "Save",
-            onPressed: () {
-              setState(() {
-                school = controller.text.trim();
-              });
-
-              Navigator.pop(context);
-              _showSnackBar("School updated");
+            onPressed: () async {
+              final value = controller.text.trim();
+              try {
+                await _profileService.updateProfile({'school': value});
+                if (!mounted) return;
+                setState(() => school = value);
+                Navigator.pop(context);
+                _showSnackBar("School updated");
+              } catch (_) {
+                _showSnackBar("Failed to update school");
+              }
             },
           ),
         ],
@@ -399,6 +508,10 @@ class _SettingsScreenState extends State<SettingsScreen> {
     );
   }
 
+  /// Uses a local [tempSelected] copy so the modal can show checkbox state
+  /// without touching [selectedCourses] until the user explicitly saves.
+  /// [Navigator.of(context)] is captured before the await to avoid using a
+  /// potentially stale BuildContext after the async gap.
   void _openCoursesSheet() {
     List<String> tempSelected = List.from(selectedCourses);
 
@@ -448,13 +561,18 @@ class _SettingsScreenState extends State<SettingsScreen> {
               const SizedBox(height: 16),
               _primaryButton(
                 label: "Save Courses",
-                onPressed: () {
-                  setState(() {
-                    selectedCourses = tempSelected;
-                  });
-
-                  Navigator.pop(context);
-                  _showSnackBar("Courses updated");
+                onPressed: () async {
+                  final nav = Navigator.of(context);
+                  try {
+                    await _profileService
+                        .updateProfile({'selectedCourses': tempSelected});
+                    if (!mounted) return;
+                    setState(() => selectedCourses = tempSelected);
+                    nav.pop();
+                    _showSnackBar("Courses updated");
+                  } catch (_) {
+                    _showSnackBar("Failed to update courses");
+                  }
                 },
               ),
             ],
@@ -464,6 +582,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
     );
   }
 
+  /// Same temp-copy + save pattern as [_openCoursesSheet], using [ChoiceChip]
+  /// instead of checkboxes for a tag-style selection UI.
   void _openSubjectsSheet() {
     List<String> tempSelected = List.from(selectedSubjects);
 
@@ -512,13 +632,18 @@ class _SettingsScreenState extends State<SettingsScreen> {
               const SizedBox(height: 24),
               _primaryButton(
                 label: "Save Subjects",
-                onPressed: () {
-                  setState(() {
-                    selectedSubjects = tempSelected;
-                  });
-
-                  Navigator.pop(context);
-                  _showSnackBar("Subjects updated");
+                onPressed: () async {
+                  final nav = Navigator.of(context);
+                  try {
+                    await _profileService
+                        .updateProfile({'selectedSubjects': tempSelected});
+                    if (!mounted) return;
+                    setState(() => selectedSubjects = tempSelected);
+                    nav.pop();
+                    _showSnackBar("Subjects updated");
+                  } catch (_) {
+                    _showSnackBar("Failed to update subjects");
+                  }
                 },
               ),
             ],
@@ -564,7 +689,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
       textSecondary: _textSecondary,
       onLogout: () async {
         try {
-          await AuthServices().signOut();
+          await _auth.signOut();
         } catch (_) {
           if (!mounted) return;
           _showSnackBar("Unable to log out. Please try again.");
@@ -572,6 +697,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
       },
     );
   }
+
+  // ── Shared UI helpers ────────────────────────────────────────────────────────
 
   Widget _themedTextField({
     required TextEditingController controller,

--- a/focusfeed/pubspec.lock
+++ b/focusfeed/pubspec.lock
@@ -93,10 +93,10 @@ packages:
     dependency: "direct main"
     description:
       name: cupertino_icons
-      sha256: ba631d1c7f7bef6b729a622b7b752645a2d076dba9976925b8f25725a30e1ee6
+      sha256: "41e005c33bd814be4d3096aff55b1908d419fde52ca656c8c47719ec745873cd"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.8"
+    version: "1.0.9"
   dbus:
     dependency: transitive
     description:
@@ -308,10 +308,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
@@ -324,10 +324,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   path:
     dependency: transitive
     description:
@@ -425,10 +425,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.9"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary

- Replace hardcoded placeholder values in `SettingsScreen` with live data loaded from Firestore on `initState`
- Add `getProfile()` and `updateProfile()` helpers to `ProfileService` for reading and merging user documents
- Refactor setup wizard (`ProfileSetupScreen`) into composable step widgets to reduce screen complexity
- Add inline documentation across auth, profile, and settings layers

## Changes

### `ProfileService`
- `getProfile()` — fetches the full `users/{uid}` document as a raw map
- `updateProfile(data)` — merges fields into `users/{uid}` with a server-side `updatedAt` timestamp

### `SettingsScreen`
- Loads real profile data on init; shows a `CircularProgressIndicator` while fetching so stale placeholders are never visible
- Falls back to `FirebaseAuth.currentUser` fields when Firestore data is missing (e.g. Google sign-in before completing setup)
- All edit dialogs persist changes via `updateProfile`:
  - **Username** — updates both Firebase Auth display name and Firestore
  - **Email** — uses `verifyBeforeUpdateEmail`; Firestore updated optimistically, Auth updates after the user clicks the verification link
  - **Password** — re-authenticates with current password before calling `updatePassword`; validates length ≥ 6
  - **School, Courses, Subjects** — persist on save, error-handled with snackbar feedback
- Toggle switches (notifications, auto-generate flashcards) use fire-and-forget writes for instant UI feedback

### Setup Wizard (`ProfileSetupScreen`)
- Extracted into focused step widgets: `SetupStepSchool`, `SetupStepCourses`, `SetupStepPreferences`
- Shared components: `SetupCard`, `ChoiceWrap`, `PreferenceSwitch`, `ThemedTextField`

### Auth (`CreateAccountScreen`)
- Added inline comments explaining password-mismatch guard, null-return handling, and stack-clearing navigation

## Test plan

-Open Settings — confirm real name, email, and school load (no placeholders)
-Edit username — verify change reflects in the app bar/profile screen
-Edit email — confirm verification email is sent; old email remains until confirmed
-Edit password — test wrong current password shows correct error; test new password works on re-login
-Toggle notifications and auto-generate — reload the screen and confirm toggles persist
-Edit courses and subjects — verify selections save and reload correctly
-Sign in via Google — confirm Settings still loads without crashing when Firestore doc fields are sparse
-Sign up via email — confirm navigation to profile setup, then to the main app