### PR TITLE
Feat/auth signup validation

### DIFF
--- a/focusfeed/ios/Flutter/Profile.xcconfig
+++ b/focusfeed/ios/Flutter/Profile.xcconfig
@@ -1,0 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"
+#include "Generated.xcconfig"

--- a/focusfeed/ios/Runner.xcodeproj/project.pbxproj
+++ b/focusfeed/ios/Runner.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		772BF5E41212324690598D50 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
 		7884E8672EC3CC0400C636F2 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
+		8C4A5C7C6A2D4BFE8F19A101 /* Profile.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Profile.xcconfig; path = Flutter/Profile.xcconfig; sourceTree = "<group>"; };
 		8B234A52866746B9D3C31AE4 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		96D83518C9CECAAD25956E65 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
@@ -127,6 +128,7 @@
 				3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */,
 				9740EEB21CF90195004384FC /* Debug.xcconfig */,
 				7AFA3C8E1D35360C0083082E /* Release.xcconfig */,
+				8C4A5C7C6A2D4BFE8F19A101 /* Profile.xcconfig */,
 				9740EEB31CF90195004384FC /* Generated.xcconfig */,
 			);
 			name = Flutter;
@@ -493,7 +495,7 @@
 		};
 		249021D4217E4FDB00AE95B9 /* Profile */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
+			baseConfigurationReference = 8C4A5C7C6A2D4BFE8F19A101 /* Profile.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -705,7 +707,7 @@
 		};
 		97C147071CF9000F007C117D /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
+			baseConfigurationReference = 8C4A5C7C6A2D4BFE8F19A101 /* Profile.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;

--- a/focusfeed/lib/features/auth/screens/create_account_screen.dart
+++ b/focusfeed/lib/features/auth/screens/create_account_screen.dart
@@ -17,6 +17,36 @@ class _CreateAccountScreenState extends State<CreateAccountScreen> {
   final confirmPasswordController = TextEditingController();
   final auth = AuthServices();
 
+//Email Regex pattern for basic validation
+  bool isValidEmail(String email) {
+    final emailRegex = RegExp(r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$');
+    return emailRegex.hasMatch(email);
+  }
+  //Empty field validation
+  String? validateFields() {
+    if (nameController.text.trim().isEmpty) {
+      return "Full Name cannot be empty";
+    }
+    if (emailController.text.trim().isEmpty) {
+      return "Email cannot be empty";
+    }
+    if (!isValidEmail(emailController.text.trim())) {
+      return "Please enter a valid email address";
+    }
+    if (passwordController.text.isEmpty) {
+      return "Password cannot be empty";
+    }
+    if (passwordController.text.length < 6) {
+  return "Password must be at least 6 characters";
+    }
+    if (confirmPasswordController.text.isEmpty) {
+      return "Confirm Password cannot be empty";
+    }
+    if (passwordController.text != confirmPasswordController.text) {
+      return "Passwords do not match";
+    }
+    return null;
+  }
   @override
   void dispose(){
     nameController.dispose();
@@ -143,17 +173,18 @@ class _CreateAccountScreenState extends State<CreateAccountScreen> {
                     shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
                   ),
                   onPressed: () async{
-                    if(passwordController.text != confirmPasswordController.text){
-                      debugPrint("Passwords don't match");
+                    final error = validateFields();
+                    if (error != null) {
+                      ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(error)));
                       return;
                     }
                     final result = await auth.signUpWithEmail(
                       emailController.text.trim(),
                       passwordController.text,
-                      );
-                      if (result == null) return;
-                      if (!context.mounted) return;
-                      Navigator.pushReplacementNamed(context, '/home');
+                    );
+                    if (result == null) return;
+                    if (!context.mounted) return;
+                    Navigator.pushReplacementNamed(context, '/home');
                   },
                   child: const Text(
                     "Create Account",

--- a/focusfeed/lib/features/auth/screens/create_account_screen.dart
+++ b/focusfeed/lib/features/auth/screens/create_account_screen.dart
@@ -11,44 +11,63 @@ class CreateAccountScreen extends StatefulWidget {
 class _CreateAccountScreenState extends State<CreateAccountScreen> {
   bool _showPassword = false;
   bool _showConfirmPassword = false;
+  final _formKey = GlobalKey<FormState>();
+  final _confirmPasswordFieldKey = GlobalKey<FormFieldState<String>>();
+
   final nameController = TextEditingController();
   final emailController = TextEditingController();
   final passwordController = TextEditingController();
   final confirmPasswordController = TextEditingController();
+
   final auth = AuthServices();
 
-//Email Regex pattern for basic validation
   bool isValidEmail(String email) {
-    final emailRegex = RegExp(r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$');
+    final emailRegex = RegExp(
+      r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$',
+    );
     return emailRegex.hasMatch(email);
   }
-  //Empty field validation
-  String? validateFields() {
-    if (nameController.text.trim().isEmpty) {
+
+  String? validateName(String? value) {
+    if (value == null || value.trim().isEmpty) {
       return "Full Name cannot be empty";
     }
-    if (emailController.text.trim().isEmpty) {
+    return null;
+  }
+
+  String? validateEmail(String? value) {
+    final email = value?.trim() ?? '';
+    if (email.isEmpty) {
       return "Email cannot be empty";
     }
-    if (!isValidEmail(emailController.text.trim())) {
+    if (!isValidEmail(email)) {
       return "Please enter a valid email address";
     }
-    if (passwordController.text.isEmpty) {
+    return null;
+  }
+
+  String? validatePassword(String? value) {
+    if (value == null || value.isEmpty) {
       return "Password cannot be empty";
     }
-    if (passwordController.text.length < 6) {
-  return "Password must be at least 6 characters";
+    if (value.length < 6) {
+      return "Password must be at least 6 characters";
     }
-    if (confirmPasswordController.text.isEmpty) {
+    return null;
+  }
+
+  String? validateConfirmPassword(String? value) {
+    if (value == null || value.isEmpty) {
       return "Confirm Password cannot be empty";
     }
-    if (passwordController.text != confirmPasswordController.text) {
+    if (passwordController.text != value) {
       return "Passwords do not match";
     }
     return null;
   }
+
   @override
-  void dispose(){
+  void dispose() {
     nameController.dispose();
     emailController.dispose();
     passwordController.dispose();
@@ -64,194 +83,222 @@ class _CreateAccountScreenState extends State<CreateAccountScreen> {
         child: Padding(
           padding: const EdgeInsets.all(24.0),
           child: SingleChildScrollView(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                // Back button
-                GestureDetector(
-                  onTap: () => Navigator.pop(context),
-                  child: const Row(
-                    mainAxisSize: MainAxisSize.min,
+            child: Form(
+              key: _formKey,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  GestureDetector(
+                    onTap: () => Navigator.pop(context),
+                    child: const Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Icon(
+                          Icons.arrow_back,
+                          color: Color.fromRGBO(133, 90, 251, 1),
+                          size: 18,
+                        ),
+                        SizedBox(width: 4),
+                        Text(
+                          "Back",
+                          style: TextStyle(
+                            color: Color.fromRGBO(133, 90, 251, 1),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(height: 30),
+                  Center(
+                    child: Container(
+                      height: 80,
+                      width: 80,
+                      decoration: BoxDecoration(
+                        color: Colors.white24,
+                        borderRadius: BorderRadius.circular(16),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 20),
+                  const Center(
+                    child: Text(
+                      "Create Account",
+                      style: TextStyle(
+                        fontSize: 28,
+                        fontWeight: FontWeight.bold,
+                        color: Color.fromRGBO(133, 90, 251, 1),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 30),
+                  _InputField(
+                    hint: "Full Name",
+                    icon: Icons.person_outline,
+                    controller: nameController,
+                    validator: validateName,
+                    textInputAction: TextInputAction.next,
+                  ),
+                  const SizedBox(height: 14),
+                  _InputField(
+                    hint: "Email",
+                    icon: Icons.email_outlined,
+                    keyboardType: TextInputType.emailAddress,
+                    controller: emailController,
+                    validator: validateEmail,
+                    textInputAction: TextInputAction.next,
+                  ),
+                  const SizedBox(height: 14),
+                  _InputField(
+                    hint: "Password",
+                    icon: Icons.lock_outline,
+                    obscure: !_showPassword,
+                    controller: passwordController,
+                    validator: validatePassword,
+                    textInputAction: TextInputAction.next,
+                    onChanged: (_) {
+                      if (confirmPasswordController.text.isNotEmpty) {
+                        _confirmPasswordFieldKey.currentState?.validate();
+                      }
+                    },
+                    suffixIcon: IconButton(
+                      icon: Icon(
+                        _showPassword
+                            ? Icons.visibility_off_outlined
+                            : Icons.remove_red_eye_outlined,
+                        color: Colors.white38,
+                        size: 20,
+                      ),
+                      onPressed: () =>
+                          setState(() => _showPassword = !_showPassword),
+                    ),
+                  ),
+                  const SizedBox(height: 14),
+                  _InputField(
+                    fieldKey: _confirmPasswordFieldKey,
+                    hint: "Confirm Password",
+                    icon: Icons.lock_outline,
+                    obscure: !_showConfirmPassword,
+                    controller: confirmPasswordController,
+                    validator: validateConfirmPassword,
+                    textInputAction: TextInputAction.done,
+                    suffixIcon: IconButton(
+                      icon: Icon(
+                        _showConfirmPassword
+                            ? Icons.visibility_off_outlined
+                            : Icons.remove_red_eye_outlined,
+                        color: Colors.white38,
+                        size: 20,
+                      ),
+                      onPressed: () => setState(
+                        () => _showConfirmPassword = !_showConfirmPassword,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 24),
+                  ElevatedButton(
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: const Color.fromRGBO(133, 90, 251, 1),
+                      minimumSize: const Size(double.infinity, 52),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                    ),
+                    onPressed: () async {
+                      final isValid =
+                          _formKey.currentState?.validate() ?? false;
+                      if (!isValid) {
+                        return;
+                      }
+
+                      final result = await auth.signUpWithEmail(
+                        emailController.text.trim(),
+                        passwordController.text,
+                      );
+
+                      if (result == null) return;
+                      if (!context.mounted) return;
+                      Navigator.pushReplacementNamed(context, '/home');
+                    },
+                    child: const Text(
+                      "Create Account",
+                      style: TextStyle(
+                        color: Colors.white,
+                        fontWeight: FontWeight.bold,
+                        fontSize: 16,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 20),
+                  Row(
                     children: [
-                      Icon(Icons.arrow_back, color: Color.fromRGBO(133, 90, 251, 1), size: 18),
-                      SizedBox(width: 4),
-                      Text("Back", style: TextStyle(color: Color.fromRGBO(133, 90, 251, 1))),
+                      const Expanded(child: Divider(color: Colors.white24)),
+                      Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 12),
+                        child: Text(
+                          "Or continue with",
+                          style: TextStyle(color: Colors.white38, fontSize: 13),
+                        ),
+                      ),
+                      const Expanded(child: Divider(color: Colors.white24)),
                     ],
                   ),
-                ),
-
-                const SizedBox(height: 30),
-
-                // Logo
-                Center(
-                  child: Container(
-                    height: 80,
-                    width: 80,
-                    decoration: BoxDecoration(
-                      color: Colors.white24,
-                      borderRadius: BorderRadius.circular(16),
-                    ),
-                  ),
-                ),
-
-                const SizedBox(height: 20),
-
-                // Title
-                const Center(
-                  child: Text(
-                    "Create Account",
-                    style: TextStyle(
-                      fontSize: 28,
-                      fontWeight: FontWeight.bold,
-                      color: Color.fromRGBO(133, 90, 251, 1),
-                    ),
-                  ),
-                ),
-
-                const SizedBox(height: 30),
-
-                // Full Name
-                _InputField(
-                  hint: "Full Name",
-                  icon: Icons.person_outline,
-                  controller: nameController,
-                ),
-
-                const SizedBox(height: 14),
-
-                // Email
-                _InputField(
-                  hint: "Email",
-                  icon: Icons.email_outlined,
-                  keyboardType: TextInputType.emailAddress,
-                  controller: emailController,
-                ),
-
-                const SizedBox(height: 14),
-
-                // Password
-                _InputField(
-                  hint: "Password",
-                  icon: Icons.lock_outline,
-                  obscure: !_showPassword,
-                  controller: passwordController,
-                  suffixIcon: IconButton(
-                    icon: Icon(
-                      _showPassword ? Icons.visibility_off_outlined : Icons.remove_red_eye_outlined,
-                      color: Colors.white38,
-                      size: 20,
-                    ),
-                    onPressed: () => setState(() => _showPassword = !_showPassword),
-                  ),
-                ),
-
-                const SizedBox(height: 14),
-
-                // Confirm Password
-                _InputField(
-                  hint: "Confirm Password",
-                  icon: Icons.lock_outline,
-                  obscure: !_showConfirmPassword,
-                  controller: confirmPasswordController,
-                  suffixIcon: IconButton(
-                    icon: Icon(
-                      _showConfirmPassword ? Icons.visibility_off_outlined : Icons.remove_red_eye_outlined,
-                      color: Colors.white38,
-                      size: 20,
-                    ),
-                    onPressed: () => setState(() => _showConfirmPassword = !_showConfirmPassword),
-                  ),
-                ),
-
-                const SizedBox(height: 24),
-
-                // Create Account Button
-                ElevatedButton(
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: const Color.fromRGBO(133, 90, 251, 1),
-                    minimumSize: const Size(double.infinity, 52),
-                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-                  ),
-                  onPressed: () async{
-                    final error = validateFields();
-                    if (error != null) {
-                      ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(error)));
-                      return;
-                    }
-                    final result = await auth.signUpWithEmail(
-                      emailController.text.trim(),
-                      passwordController.text,
-                    );
-                    if (result == null) return;
-                    if (!context.mounted) return;
-                    Navigator.pushReplacementNamed(context, '/home');
-                  },
-                  child: const Text(
-                    "Create Account",
-                    style: TextStyle(color: Colors.white, fontWeight: FontWeight.bold, fontSize: 16),
-                  ),
-                ),
-
-                const SizedBox(height: 20),
-
-                // Or continue with
-                Row(
-                  children: [
-                    const Expanded(child: Divider(color: Colors.white24)),
-                    Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 12),
-                      child: Text("Or continue with", style: TextStyle(color: Colors.white38, fontSize: 13)),
-                    ),
-                    const Expanded(child: Divider(color: Colors.white24)),
-                  ],
-                ),
-
-                const SizedBox(height: 16),
-
-                // Google Button
-                Row(
-                  children: [
-                    Expanded(
-                      child: OutlinedButton.icon(
-                        style: OutlinedButton.styleFrom(
-                          side: const BorderSide(color: Colors.white24),
-                          padding: const EdgeInsets.symmetric(vertical: 14),
-                          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-                        ),
-                        onPressed: () async{
-                          final result = await auth.signInWithGoogle();
-                          if (result == null) return;
-                          if (!context.mounted) return;
-                          Navigator.pushReplacementNamed(context, '/home');
-                        },
-                        icon: const Text("G", style: TextStyle(color: Colors.white, fontWeight: FontWeight.bold, fontSize: 16)),
-                        label: const Text("Google", style: TextStyle(color: Colors.white)),
-                      ),
-                    ),
-                  ],
-                ),
-
-                const SizedBox(height: 20),
-
-                // Already have an account
-                GestureDetector(
-                  onTap: () => Navigator.pop(context),
-                  child: Center(
-                    child: RichText(
-                      text: const TextSpan(
-                        text: "Already have an account? ",
-                        style: TextStyle(color: Colors.white54, fontSize: 13),
-                        children: [
-                          TextSpan(
-                            text: "Login",
-                            style: TextStyle(color: Color.fromRGBO(133, 90, 251, 1), fontWeight: FontWeight.bold),
+                  const SizedBox(height: 16),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: OutlinedButton.icon(
+                          style: OutlinedButton.styleFrom(
+                            side: const BorderSide(color: Colors.white24),
+                            padding: const EdgeInsets.symmetric(vertical: 14),
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(12),
+                            ),
                           ),
-                        ],
+                          onPressed: () async {
+                            final result = await auth.signInWithGoogle();
+                            if (result == null) return;
+                            if (!context.mounted) return;
+                            Navigator.pushReplacementNamed(context, '/home');
+                          },
+                          icon: const Text(
+                            "G",
+                            style: TextStyle(
+                              color: Colors.white,
+                              fontWeight: FontWeight.bold,
+                              fontSize: 16,
+                            ),
+                          ),
+                          label: const Text(
+                            "Google",
+                            style: TextStyle(color: Colors.white),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 20),
+                  GestureDetector(
+                    onTap: () => Navigator.pop(context),
+                    child: Center(
+                      child: RichText(
+                        text: const TextSpan(
+                          text: "Already have an account? ",
+                          style: TextStyle(color: Colors.white54, fontSize: 13),
+                          children: [
+                            TextSpan(
+                              text: "Login",
+                              style: TextStyle(
+                                color: Color.fromRGBO(133, 90, 251, 1),
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                          ],
+                        ),
                       ),
                     ),
                   ),
-                ),
-              ],
+                ],
+              ),
             ),
           ),
         ),
@@ -261,41 +308,65 @@ class _CreateAccountScreenState extends State<CreateAccountScreen> {
 }
 
 class _InputField extends StatelessWidget {
+  final Key? fieldKey;
   final TextEditingController? controller;
   final String hint;
   final IconData icon;
   final bool obscure;
   final TextInputType? keyboardType;
   final Widget? suffixIcon;
+  final String? Function(String?)? validator;
+  final void Function(String)? onChanged;
+  final TextInputAction? textInputAction;
 
   const _InputField({
+    this.fieldKey,
     required this.hint,
     required this.icon,
     this.controller,
     this.obscure = false,
     this.keyboardType,
     this.suffixIcon,
+    this.validator,
+    this.onChanged,
+    this.textInputAction,
   });
 
   @override
   Widget build(BuildContext context) {
-    return TextField(
+    return TextFormField(
+      key: fieldKey,
       controller: controller,
       obscureText: obscure,
       keyboardType: keyboardType,
+      validator: validator,
+      onChanged: onChanged,
+      textInputAction: textInputAction,
+      autovalidateMode: AutovalidateMode.onUserInteraction,
       style: const TextStyle(color: Colors.white),
       decoration: InputDecoration(
         hintText: hint,
         hintStyle: const TextStyle(color: Colors.white38),
         prefixIcon: Icon(icon, color: Colors.white38, size: 20),
         suffixIcon: suffixIcon,
+        errorStyle: const TextStyle(color: Color(0xFFFF8A80)),
         enabledBorder: OutlineInputBorder(
           borderRadius: BorderRadius.circular(12),
-          borderSide: const BorderSide(color: Color.fromRGBO(133, 90, 251, 0.4)),
+          borderSide: const BorderSide(
+            color: Color.fromRGBO(133, 90, 251, 0.4),
+          ),
         ),
         focusedBorder: OutlineInputBorder(
           borderRadius: BorderRadius.circular(12),
           borderSide: const BorderSide(color: Color.fromRGBO(133, 90, 251, 1)),
+        ),
+        errorBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(12),
+          borderSide: const BorderSide(color: Color(0xFFFF8A80)),
+        ),
+        focusedErrorBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(12),
+          borderSide: const BorderSide(color: Color(0xFFFF8A80), width: 1.5),
         ),
       ),
     );

--- a/focusfeed/lib/features/auth/screens/create_account_screen.dart
+++ b/focusfeed/lib/features/auth/screens/create_account_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:focusfeed/features/auth/screens/login_screen.dart';
 import 'package:focusfeed/features/auth/services/auth_service.dart';
 
 class CreateAccountScreen extends StatefulWidget {
@@ -9,11 +10,13 @@ class CreateAccountScreen extends StatefulWidget {
 }
 
 class _CreateAccountScreenState extends State<CreateAccountScreen> {
+  static const bool _googleSignInEnabled = true;
   bool _showPassword = false;
   bool _showConfirmPassword = false;
   final _formKey = GlobalKey<FormState>();
   final _confirmPasswordFieldKey = GlobalKey<FormFieldState<String>>();
-
+  bool _isLoading = false;
+  String? _authError;
   final nameController = TextEditingController();
   final emailController = TextEditingController();
   final passwordController = TextEditingController();
@@ -21,13 +24,14 @@ class _CreateAccountScreenState extends State<CreateAccountScreen> {
 
   final auth = AuthServices();
 
+// Simple email validation using regex
   bool isValidEmail(String email) {
     final emailRegex = RegExp(
       r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$',
     );
     return emailRegex.hasMatch(email);
   }
-
+// Validation functions for each field
   String? validateName(String? value) {
     if (value == null || value.trim().isEmpty) {
       return "Full Name cannot be empty";
@@ -64,6 +68,72 @@ class _CreateAccountScreenState extends State<CreateAccountScreen> {
       return "Passwords do not match";
     }
     return null;
+  }
+  // Handle create account logic
+  Future<void> _handleCreateAccount() async {
+    final isValid = _formKey.currentState?.validate() ?? false;
+
+    if (!isValid || _isLoading) {
+      return;
+    }
+
+    setState(() {
+      _isLoading = true;
+      _authError = null;
+    });
+
+    try {
+      await auth.signUpWithEmail(
+        emailController.text.trim(),
+        passwordController.text,
+        displayName: nameController.text,
+      );
+
+      if (!mounted) return;
+      Navigator.pushNamedAndRemoveUntil(context, '/auth-gate', (route) => false);
+    } catch (e) {
+      if (!mounted) return;
+
+      setState(() {
+        _authError = e.toString().replaceFirst('Exception: ', '');
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+      }
+    }
+  }
+
+  Future<void> _handleGoogleSignIn() async {
+    if (_isLoading) {
+      return;
+    }
+
+    setState(() {
+      _isLoading = true;
+      _authError = null;
+    });
+
+    try {
+      await auth.signInWithGoogle();
+
+      if (!mounted) return;
+      Navigator.pushNamedAndRemoveUntil(context, '/auth-gate', (route) => false);
+    } catch (e) {
+      if (!mounted) return;
+
+      setState(() {
+        _authError = e.toString().replaceFirst('Exception: ', '');
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+      }
+    }
   }
 
   @override
@@ -131,6 +201,7 @@ class _CreateAccountScreenState extends State<CreateAccountScreen> {
                     ),
                   ),
                   const SizedBox(height: 30),
+                  // Input fields
                   _InputField(
                     hint: "Full Name",
                     icon: Icons.person_outline,
@@ -138,6 +209,7 @@ class _CreateAccountScreenState extends State<CreateAccountScreen> {
                     validator: validateName,
                     textInputAction: TextInputAction.next,
                   ),
+                  
                   const SizedBox(height: 14),
                   _InputField(
                     hint: "Email",
@@ -148,6 +220,7 @@ class _CreateAccountScreenState extends State<CreateAccountScreen> {
                     textInputAction: TextInputAction.next,
                   ),
                   const SizedBox(height: 14),
+
                   _InputField(
                     hint: "Password",
                     icon: Icons.lock_outline,
@@ -168,8 +241,11 @@ class _CreateAccountScreenState extends State<CreateAccountScreen> {
                         color: Colors.white38,
                         size: 20,
                       ),
-                      onPressed: () =>
-                          setState(() => _showPassword = !_showPassword),
+                      onPressed: () {
+                        setState(() {
+                          _showPassword = !_showPassword;
+                        });
+                      },
                     ),
                   ),
                   const SizedBox(height: 14),
@@ -189,12 +265,23 @@ class _CreateAccountScreenState extends State<CreateAccountScreen> {
                         color: Colors.white38,
                         size: 20,
                       ),
-                      onPressed: () => setState(
-                        () => _showConfirmPassword = !_showConfirmPassword,
-                      ),
+                      onPressed: () {
+                        setState(() {
+                          _showConfirmPassword = !_showConfirmPassword;
+                        });
+                      },
                     ),
                   ),
                   const SizedBox(height: 24),
+                  // Display authentication error if exists
+                  if (_authError != null) ...[
+                    Text(
+                      _authError!,
+                      style: const TextStyle(color: Color(0xFFFF8A80)),
+                    ),
+                    const SizedBox(height: 12),
+                  ],
+
                   ElevatedButton(
                     style: ElevatedButton.styleFrom(
                       backgroundColor: const Color.fromRGBO(133, 90, 251, 1),
@@ -203,82 +290,85 @@ class _CreateAccountScreenState extends State<CreateAccountScreen> {
                         borderRadius: BorderRadius.circular(12),
                       ),
                     ),
-                    onPressed: () async {
-                      final isValid =
-                          _formKey.currentState?.validate() ?? false;
-                      if (!isValid) {
-                        return;
-                      }
-
-                      final result = await auth.signUpWithEmail(
-                        emailController.text.trim(),
-                        passwordController.text,
-                      );
-
-                      if (result == null) return;
-                      if (!context.mounted) return;
-                      Navigator.pushReplacementNamed(context, '/home');
-                    },
-                    child: const Text(
-                      "Create Account",
-                      style: TextStyle(
-                        color: Colors.white,
-                        fontWeight: FontWeight.bold,
-                        fontSize: 16,
-                      ),
-                    ),
-                  ),
-                  const SizedBox(height: 20),
-                  Row(
-                    children: [
-                      const Expanded(child: Divider(color: Colors.white24)),
-                      Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 12),
-                        child: Text(
-                          "Or continue with",
-                          style: TextStyle(color: Colors.white38, fontSize: 13),
-                        ),
-                      ),
-                      const Expanded(child: Divider(color: Colors.white24)),
-                    ],
-                  ),
-                  const SizedBox(height: 16),
-                  Row(
-                    children: [
-                      Expanded(
-                        child: OutlinedButton.icon(
-                          style: OutlinedButton.styleFrom(
-                            side: const BorderSide(color: Colors.white24),
-                            padding: const EdgeInsets.symmetric(vertical: 14),
-                            shape: RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(12),
+                    // Disable button when loading to prevent multiple submissions
+                    onPressed: _isLoading ? null : _handleCreateAccount,
+                    child: _isLoading
+                        ? const SizedBox(
+                            height: 20,
+                            width: 20,
+                            child: CircularProgressIndicator(
+                              strokeWidth: 2,
+                              color: Colors.white,
                             ),
-                          ),
-                          onPressed: () async {
-                            final result = await auth.signInWithGoogle();
-                            if (result == null) return;
-                            if (!context.mounted) return;
-                            Navigator.pushReplacementNamed(context, '/home');
-                          },
-                          icon: const Text(
-                            "G",
+                          )
+                        : const Text(
+                            "Create Account",
                             style: TextStyle(
                               color: Colors.white,
                               fontWeight: FontWeight.bold,
                               fontSize: 16,
                             ),
                           ),
-                          label: const Text(
-                            "Google",
-                            style: TextStyle(color: Colors.white),
-                          ),
-                        ),
-                      ),
-                    ],
                   ),
                   const SizedBox(height: 20),
+                  if (_googleSignInEnabled) ...[
+                    Row(
+                      children: [
+                        const Expanded(child: Divider(color: Colors.white24)),
+                        Padding(
+                          padding: const EdgeInsets.symmetric(horizontal: 12),
+                          child: Text(
+                            "Or continue with",
+                            style: TextStyle(
+                              color: Colors.white38,
+                              fontSize: 13,
+                            ),
+                          ),
+                        ),
+                        const Expanded(child: Divider(color: Colors.white24)),
+                      ],
+                    ),
+                    const SizedBox(height: 16),
+                    Row(
+                      children: [
+                        Expanded(
+                          child: OutlinedButton.icon(
+                            style: OutlinedButton.styleFrom(
+                              side: const BorderSide(color: Colors.white24),
+                              padding: const EdgeInsets.symmetric(vertical: 14),
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(12),
+                              ),
+                            ),
+                            onPressed: _isLoading ? null : _handleGoogleSignIn,
+                            icon: const Text(
+                              "G",
+                              style: TextStyle(
+                                color: Colors.white,
+                                fontWeight: FontWeight.bold,
+                                fontSize: 16,
+                              ),
+                            ),
+                            label: const Text(
+                              "Google",
+                              style: TextStyle(color: Colors.white),
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 20),
+                  ],
+
                   GestureDetector(
-                    onTap: () => Navigator.pop(context),
+                    onTap: () {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (context) => const LoginScreen(),
+                        ),
+                      );
+                    },
                     child: Center(
                       child: RichText(
                         text: const TextSpan(
@@ -358,7 +448,9 @@ class _InputField extends StatelessWidget {
         ),
         focusedBorder: OutlineInputBorder(
           borderRadius: BorderRadius.circular(12),
-          borderSide: const BorderSide(color: Color.fromRGBO(133, 90, 251, 1)),
+          borderSide: const BorderSide(
+            color: Color.fromRGBO(133, 90, 251, 1),
+          ),
         ),
         errorBorder: OutlineInputBorder(
           borderRadius: BorderRadius.circular(12),

--- a/focusfeed/lib/features/auth/screens/login_screen.dart
+++ b/focusfeed/lib/features/auth/screens/login_screen.dart
@@ -9,13 +9,142 @@ class LoginScreen extends StatefulWidget {
 }
 
 class _LoginScreenState extends State<LoginScreen> {
+  static const bool _googleSignInEnabled = true;
   bool _showPassword = false;
+  bool _isLoading = false;
+  String? _authError;
+  final _formKey = GlobalKey<FormState>();
   final emailController = TextEditingController();
   final passwordController = TextEditingController();
   final auth = AuthServices();
 
+  bool isValidEmail(String email) {
+    final emailRegex = RegExp(
+      r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$',
+    );
+    return emailRegex.hasMatch(email);
+  }
+
+  String? validateEmail(String? value) {
+    final email = value?.trim() ?? '';
+    if (email.isEmpty) {
+      return 'Email cannot be empty';
+    }
+    if (!isValidEmail(email)) {
+      return 'Please enter a valid email address';
+    }
+    return null;
+  }
+
+  String? validatePassword(String? value) {
+    if (value == null || value.isEmpty) {
+      return 'Password cannot be empty';
+    }
+    return null;
+  }
+
+  Future<void> _handleLogin() async {
+    final isValid = _formKey.currentState?.validate() ?? false;
+    if (!isValid || _isLoading) return;
+
+    setState(() {
+      _isLoading = true;
+      _authError = null;
+    });
+
+    try {
+      await auth.signInWithEmail(
+        emailController.text.trim(),
+        passwordController.text,
+      );
+      if (!mounted) return;
+      Navigator.pushNamedAndRemoveUntil(context, '/auth-gate', (route) => false);
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _authError = e.toString().replaceFirst('Exception: ', '');
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+      }
+    }
+  }
+
+  Future<void> _handleGoogleLogin() async {
+    if (_isLoading) return;
+
+    setState(() {
+      _isLoading = true;
+      _authError = null;
+    });
+
+    try {
+      await auth.signInWithGoogle();
+      if (!mounted) return;
+      Navigator.pushNamedAndRemoveUntil(context, '/auth-gate', (route) => false);
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _authError = e.toString().replaceFirst('Exception: ', '');
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+      }
+    }
+  }
+
+  Future<void> _handleForgotPassword() async {
+    final email = emailController.text.trim();
+
+    if (email.isEmpty) {
+      setState(() {
+        _authError = 'Enter your email first to reset your password.';
+      });
+      return;
+    }
+
+    if (!isValidEmail(email)) {
+      setState(() {
+        _authError = 'Please enter a valid email address.';
+      });
+      return;
+    }
+
+    setState(() {
+      _isLoading = true;
+      _authError = null;
+    });
+
+    try {
+      await auth.sendPasswordResetEmail(email);
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Password reset email sent. Check your inbox.'),
+        ),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _authError = e.toString().replaceFirst('Exception: ', '');
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+      }
+    }
+  }
+
   @override
-  void dispose(){
+  void dispose() {
     emailController.dispose();
     passwordController.dispose();
     super.dispose();
@@ -29,9 +158,11 @@ class _LoginScreenState extends State<LoginScreen> {
         child: Padding(
           padding: const EdgeInsets.all(24.0),
           child: SingleChildScrollView(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
+            child: Form(
+              key: _formKey,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
                 // Back button
                 GestureDetector(
                   onTap: () => Navigator.pop(context),
@@ -78,14 +209,18 @@ class _LoginScreenState extends State<LoginScreen> {
                 const SizedBox(height: 36),
 
                 // Email
-                TextField(
+                TextFormField(
                   controller: emailController,
                   keyboardType: TextInputType.emailAddress,
+                  textInputAction: TextInputAction.next,
+                  validator: validateEmail,
+                  autovalidateMode: AutovalidateMode.onUserInteraction,
                   style: const TextStyle(color: Colors.white),
                   decoration: InputDecoration(
                     hintText: "Email",
                     hintStyle: const TextStyle(color: Colors.white38),
                     prefixIcon: const Icon(Icons.email_outlined, color: Colors.white38, size: 20),
+                    errorStyle: const TextStyle(color: Color(0xFFFF8A80)),
                     enabledBorder: OutlineInputBorder(
                       borderRadius: BorderRadius.circular(12),
                       borderSide: const BorderSide(color: Color.fromRGBO(133, 90, 251, 0.4)),
@@ -100,9 +235,11 @@ class _LoginScreenState extends State<LoginScreen> {
                 const SizedBox(height: 14),
 
                 // Password
-                TextField(
+                TextFormField(
                   controller: passwordController,
                   obscureText: !_showPassword,
+                  validator: validatePassword,
+                  autovalidateMode: AutovalidateMode.onUserInteraction,
                   style: const TextStyle(color: Colors.white),
                   decoration: InputDecoration(
                     hintText: "Password",
@@ -127,7 +264,28 @@ class _LoginScreenState extends State<LoginScreen> {
                   ),
                 ),
 
+                Align(
+                  alignment: Alignment.centerRight,
+                  child: TextButton(
+                    onPressed: _isLoading ? null : _handleForgotPassword,
+                    child: const Text(
+                      'Forgot password?',
+                      style: TextStyle(
+                        color: Color.fromRGBO(133, 90, 251, 1),
+                      ),
+                    ),
+                  ),
+                ),
+
                 const SizedBox(height: 24),
+
+                if (_authError != null) ...[
+                  Text(
+                    _authError!,
+                    style: const TextStyle(color: Color(0xFFFF8A80)),
+                  ),
+                  const SizedBox(height: 12),
+                ],
 
                 // Login Button
                 ElevatedButton(
@@ -136,56 +294,64 @@ class _LoginScreenState extends State<LoginScreen> {
                     minimumSize: const Size(double.infinity, 52),
                     shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
                   ),
-                  onPressed: () async{
-                    final result = await auth.signInWithEmail(
-                      emailController.text.trim(),
-                      passwordController.text,
-                      );
-                      if (result == null) return;
-                      if (!context.mounted) return;
-                      Navigator.pushReplacementNamed(context, '/home');
-                  },
-                  child: const Text(
-                    "Login",
-                    style: TextStyle(color: Colors.white, fontWeight: FontWeight.bold, fontSize: 16),
-                  ),
+                  onPressed: _isLoading ? null : _handleLogin,
+                  child: _isLoading
+                      ? const SizedBox(
+                          height: 20,
+                          width: 20,
+                          child: CircularProgressIndicator(
+                            strokeWidth: 2,
+                            color: Colors.white,
+                          ),
+                        )
+                      : const Text(
+                          "Login",
+                          style: TextStyle(color: Colors.white, fontWeight: FontWeight.bold, fontSize: 16),
+                        ),
                 ),
 
                 const SizedBox(height: 20),
 
-                // Or continue with
-                Row(
-                  children: [
-                    const Expanded(child: Divider(color: Colors.white24)),
-                    Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 12),
-                      child: Text("Or continue with", style: TextStyle(color: Colors.white38, fontSize: 13)),
+                if (_googleSignInEnabled) ...[
+                  Row(
+                    children: [
+                      const Expanded(child: Divider(color: Colors.white24)),
+                      Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 12),
+                        child: Text(
+                          "Or continue with",
+                          style: TextStyle(color: Colors.white38, fontSize: 13),
+                        ),
+                      ),
+                      const Expanded(child: Divider(color: Colors.white24)),
+                    ],
+                  ),
+                  const SizedBox(height: 16),
+                  OutlinedButton.icon(
+                    style: OutlinedButton.styleFrom(
+                      side: const BorderSide(color: Colors.white24),
+                      minimumSize: const Size(double.infinity, 52),
+                      padding: const EdgeInsets.symmetric(vertical: 14),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(12),
+                      ),
                     ),
-                    const Expanded(child: Divider(color: Colors.white24)),
-                  ],
-                ),
-
-                const SizedBox(height: 16),
-
-                // Google
-                OutlinedButton.icon(
-                  style: OutlinedButton.styleFrom(
-                    side: const BorderSide(color: Colors.white24),
-                    minimumSize: const Size(double.infinity, 52),
-                    padding: const EdgeInsets.symmetric(vertical: 14),
-                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                    onPressed: _isLoading ? null : _handleGoogleLogin,
+                    icon: const Text(
+                      "G",
+                      style: TextStyle(
+                        color: Colors.white,
+                        fontWeight: FontWeight.bold,
+                        fontSize: 16,
+                      ),
+                    ),
+                    label: const Text(
+                      "Google",
+                      style: TextStyle(color: Colors.white),
+                    ),
                   ),
-                  onPressed: () async{
-                    final result = await auth.signInWithGoogle();
-                    if (result == null) return;
-                    if (!context.mounted) return;
-                    Navigator.pushReplacementNamed(context, '/home');
-                  },
-                  icon: const Text("G", style: TextStyle(color: Colors.white, fontWeight: FontWeight.bold, fontSize: 16)),
-                  label: const Text("Google", style: TextStyle(color: Colors.white)),
-                ),
-
-                const SizedBox(height: 20),
+                  const SizedBox(height: 20),
+                ],
 
                 // Don't have an account
                 GestureDetector(
@@ -205,7 +371,8 @@ class _LoginScreenState extends State<LoginScreen> {
                     ),
                   ),
                 ),
-              ],
+                ],
+              ),
             ),
           ),
         ),

--- a/focusfeed/lib/features/auth/screens/welcome_screen.dart
+++ b/focusfeed/lib/features/auth/screens/welcome_screen.dart
@@ -121,16 +121,18 @@ class WelcomeScreen extends StatelessWidget {
               ),
             ),
 
-            Positioned(
-              bottom: 30,
-              right: 20,
-              child: FloatingActionButton(
-                mini: true,
-                backgroundColor: Colors.grey,
-                onPressed: () {
-                  Navigator.pushReplacementNamed(context, '/home');
-                },
-                child: const Icon(Icons.bug_report),
+            Align(
+              alignment: Alignment.centerRight,
+              child: Padding(
+                padding: const EdgeInsets.only(top: 30),
+                child: FloatingActionButton(
+                  mini: true,
+                  backgroundColor: Colors.grey,
+                  onPressed: () {
+                    Navigator.pushReplacementNamed(context, '/home');
+                  },
+                  child: const Icon(Icons.bug_report),
+                ),
               ),
             ),
           ],

--- a/focusfeed/lib/features/auth/services/auth_service.dart
+++ b/focusfeed/lib/features/auth/services/auth_service.dart
@@ -2,7 +2,6 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/foundation.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 
-
 class AuthServices {
   final auth = FirebaseAuth.instance;
 

--- a/focusfeed/lib/features/auth/services/auth_service.dart
+++ b/focusfeed/lib/features/auth/services/auth_service.dart
@@ -5,50 +5,113 @@ import 'package:google_sign_in/google_sign_in.dart';
 class AuthServices {
   final auth = FirebaseAuth.instance;
 
-  // Sign up with email/password
-  Future<UserCredential?> signUpWithEmail(String email, String password) async {
-    try {
-      return await auth.createUserWithEmailAndPassword(email: email, password: password);
-    } on FirebaseAuthException catch (e) {
-      debugPrint(e.message);
-      return null;
+  // Convert Firebase auth error codes into clear user-facing messages
+  String _mapAuthError(FirebaseAuthException e) {
+    switch (e.code) {
+      case 'invalid-email':
+        return 'Please enter a valid email address.';
+      case 'weak-password':
+        return 'Password must be at least 6 characters.';
+      case 'email-already-in-use':
+        return 'An account already exists for that email.';
+      case 'wrong-password':
+      case 'invalid-credential':
+        return 'Incorrect email or password.';
+      case 'user-not-found':
+        return 'No account found for that email.';
+      case 'too-many-requests':
+        return 'Too many attempts. Please try again later.';
+      case 'network-request-failed':
+        return 'Network error. Check your connection and try again.';
+      default:
+        return e.message ?? 'Authentication failed. Please try again.';
     }
   }
-  // Sign in with email/password
-  Future<UserCredential?> signInWithEmail( String email, String password) async {
+
+  // Sign up with email/password and throw readable errors back to the UI
+  Future<UserCredential> signUpWithEmail(
+    String email,
+    String password, {
+    String? displayName,
+  }) async {
     try {
-      return await auth.signInWithEmailAndPassword(email: email, password: password);
+      final credential = await auth.createUserWithEmailAndPassword(
+        email: email.trim(),
+        password: password,
+      );
+
+      final trimmedDisplayName = displayName?.trim();
+      if (trimmedDisplayName != null && trimmedDisplayName.isNotEmpty) {
+        await credential.user?.updateDisplayName(trimmedDisplayName);
+      }
+
+      return credential;
     } on FirebaseAuthException catch (e) {
-      debugPrint(e.message);
-      return null;
+      debugPrint('Sign up failed: ${e.code} - ${e.message}');
+      throw Exception(_mapAuthError(e));
     }
   }
-  // Google Sign in
-  Future<UserCredential?> signInWithGoogle() async {
+
+  // Sign in with email/password and throw readable errors back to the UI
+  Future<UserCredential> signInWithEmail(String email, String password) async {
+    try {
+      return await auth.signInWithEmailAndPassword(
+        email: email.trim(),
+        password: password,
+      );
+    } on FirebaseAuthException catch (e) {
+      debugPrint('Login failed: ${e.code} - ${e.message}');
+      throw Exception(_mapAuthError(e));
+    }
+  }
+
+  // Sign in with Google and surface cancellation/errors clearly to the UI
+  Future<UserCredential> signInWithGoogle() async {
     try {
       final googleUser = await GoogleSignIn().signIn();
       if (googleUser == null) {
-        return null;
+        throw Exception('Google sign-in was cancelled.');
       }
+
       final googleAuth = await googleUser.authentication;
       final credential = GoogleAuthProvider.credential(
         accessToken: googleAuth.accessToken,
-        idToken: googleAuth.idToken
+        idToken: googleAuth.idToken,
       );
+
       return await auth.signInWithCredential(credential);
     } on FirebaseAuthException catch (e) {
-      debugPrint(e.toString());
-      return null;
+      debugPrint('Google sign-in failed: ${e.code} - ${e.message}');
+      throw Exception(_mapAuthError(e));
+    } catch (e) {
+      debugPrint('Google sign-in failed: $e');
+      rethrow;
     }
   }
-  // Sign out
-  Future<void> signOut() async {
-    await GoogleSignIn().signOut();
-    await auth.signOut();
+
+  // Send a password reset email to an existing account
+  Future<void> sendPasswordResetEmail(String email) async {
+    try {
+      await auth.sendPasswordResetEmail(email: email.trim());
+    } on FirebaseAuthException catch (e) {
+      debugPrint('Password reset failed: ${e.code} - ${e.message}');
+      throw Exception(_mapAuthError(e));
+    }
   }
-  // Who is logged in right now?
+
+  // Sign out of both Firebase and Google to fully clear the session
+  Future<void> signOut() async {
+    await auth.signOut();
+
+    try {
+      await GoogleSignIn().signOut();
+    } catch (e) {
+      debugPrint('Google sign-out cleanup failed: $e');
+    }
+  }
+  // Who is logged in right now
   User? get currentUser => auth.currentUser;
 
-  // A stream that fires whenever login state changes
+  // A stream that fires whenever the authentication state changes
   Stream<User?> get authStateChanges => auth.authStateChanges();
 }

--- a/focusfeed/lib/features/screens/settings/settings_screen.dart
+++ b/focusfeed/lib/features/screens/settings/settings_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:focusfeed/features/auth/services/auth_service.dart';
 import 'settings_modals.dart';
 import 'settings_widgets.dart';
 
@@ -10,6 +11,7 @@ class SettingsScreen extends StatefulWidget {
 }
 
 class _SettingsScreenState extends State<SettingsScreen> {
+  final auth = AuthServices();
   String username = "Cardini Panini";
   String email = "Cardini@gmail.com";
   String passwordMasked = "••••••••";
@@ -562,7 +564,21 @@ class _SettingsScreenState extends State<SettingsScreen> {
       textPrimary: _textPrimary,
       textSecondary: _textSecondary,
       onLogout: () {
-        _showSnackBar("Logged out");
+        auth
+            .signOut()
+            .then((_) {
+              if (!mounted) return;
+              _showSnackBar("Logged out");
+              Navigator.pushNamedAndRemoveUntil(
+                context,
+                '/auth-gate',
+                (route) => false,
+              );
+            })
+            .catchError((_) {
+              if (!mounted) return;
+              _showSnackBar("Could not log out. Please try again.");
+            });
       },
     );
   }

--- a/focusfeed/lib/main.dart
+++ b/focusfeed/lib/main.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'firebase_options.dart';
+import 'features/auth/services/auth_service.dart';
 import 'features/auth/screens/welcome_screen.dart';
 import 'features/auth/screens/create_account_screen.dart';
+import 'features/auth/screens/login_screen.dart';
 import 'features/screens/main_nav_screen.dart';
 
 void main() async {
@@ -20,10 +22,43 @@ class FocusFeed extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       debugShowCheckedModeBanner: false,
-      home: const WelcomeScreen(),
+      home: const _AuthGate(),
       routes: {
+        '/auth-gate': (context) => const _AuthGate(),
         '/home': (context) => const MainNavScreen(),
         '/signup': (context) => const CreateAccountScreen(),
+        '/login': (context) => const LoginScreen(),
+      },
+    );
+  }
+}
+
+class _AuthGate extends StatelessWidget {
+  const _AuthGate();
+
+  @override
+  Widget build(BuildContext context) {
+    final auth = AuthServices();
+
+    return StreamBuilder(
+      stream: auth.authStateChanges,
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const Scaffold(
+            backgroundColor: Color(0xFF0B0F2A),
+            body: Center(
+              child: CircularProgressIndicator(
+                color: Color.fromRGBO(133, 90, 251, 1),
+              ),
+            ),
+          );
+        }
+
+        if (snapshot.hasData) {
+          return const MainNavScreen();
+        }
+
+        return const WelcomeScreen();
       },
     );
   }

--- a/focusfeed/macos/Podfile.lock
+++ b/focusfeed/macos/Podfile.lock
@@ -1,0 +1,151 @@
+PODS:
+  - AppAuth (1.7.6):
+    - AppAuth/Core (= 1.7.6)
+    - AppAuth/ExternalUserAgent (= 1.7.6)
+  - AppAuth/Core (1.7.6)
+  - AppAuth/ExternalUserAgent (1.7.6):
+    - AppAuth/Core
+  - AppCheckCore (11.2.0):
+    - GoogleUtilities/Environment (~> 8.0)
+    - GoogleUtilities/UserDefaults (~> 8.0)
+    - PromisesObjC (~> 2.4)
+  - Firebase/Auth (12.9.0):
+    - Firebase/CoreOnly
+    - FirebaseAuth (~> 12.9.0)
+  - Firebase/CoreOnly (12.9.0):
+    - FirebaseCore (~> 12.9.0)
+  - firebase_auth (6.3.0):
+    - Firebase/Auth (~> 12.9.0)
+    - Firebase/CoreOnly (~> 12.9.0)
+    - firebase_core
+    - FlutterMacOS
+  - firebase_core (4.6.0):
+    - Firebase/CoreOnly (~> 12.9.0)
+    - FlutterMacOS
+  - FirebaseAppCheckInterop (12.9.0)
+  - FirebaseAuth (12.9.0):
+    - FirebaseAppCheckInterop (~> 12.9.0)
+    - FirebaseAuthInterop (~> 12.9.0)
+    - FirebaseCore (~> 12.9.0)
+    - FirebaseCoreExtension (~> 12.9.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 8.1)
+    - GoogleUtilities/Environment (~> 8.1)
+    - GTMSessionFetcher/Core (< 6.0, >= 3.4)
+    - RecaptchaInterop (~> 101.0)
+  - FirebaseAuthInterop (12.9.0)
+  - FirebaseCore (12.9.0):
+    - FirebaseCoreInternal (~> 12.9.0)
+    - GoogleUtilities/Environment (~> 8.1)
+    - GoogleUtilities/Logger (~> 8.1)
+  - FirebaseCoreExtension (12.9.0):
+    - FirebaseCore (~> 12.9.0)
+  - FirebaseCoreInternal (12.9.0):
+    - "GoogleUtilities/NSData+zlib (~> 8.1)"
+  - FlutterMacOS (1.0.0)
+  - google_sign_in_ios (0.0.1):
+    - AppAuth (>= 1.7.4)
+    - Flutter
+    - FlutterMacOS
+    - GoogleSignIn (~> 8.0)
+    - GTMSessionFetcher (>= 3.4.0)
+  - GoogleSignIn (8.0.0):
+    - AppAuth (< 2.0, >= 1.7.3)
+    - AppCheckCore (~> 11.0)
+    - GTMAppAuth (< 5.0, >= 4.1.1)
+    - GTMSessionFetcher/Core (~> 3.3)
+  - GoogleUtilities/AppDelegateSwizzler (8.1.0):
+    - GoogleUtilities/Environment
+    - GoogleUtilities/Logger
+    - GoogleUtilities/Network
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/Environment (8.1.0):
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/Logger (8.1.0):
+    - GoogleUtilities/Environment
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/Network (8.1.0):
+    - GoogleUtilities/Logger
+    - "GoogleUtilities/NSData+zlib"
+    - GoogleUtilities/Privacy
+    - GoogleUtilities/Reachability
+  - "GoogleUtilities/NSData+zlib (8.1.0)":
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/Privacy (8.1.0)
+  - GoogleUtilities/Reachability (8.1.0):
+    - GoogleUtilities/Logger
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/UserDefaults (8.1.0):
+    - GoogleUtilities/Logger
+    - GoogleUtilities/Privacy
+  - GTMAppAuth (4.1.1):
+    - AppAuth/Core (~> 1.7)
+    - GTMSessionFetcher/Core (< 4.0, >= 3.3)
+  - GTMSessionFetcher (3.5.0):
+    - GTMSessionFetcher/Full (= 3.5.0)
+  - GTMSessionFetcher/Core (3.5.0)
+  - GTMSessionFetcher/Full (3.5.0):
+    - GTMSessionFetcher/Core
+  - PromisesObjC (2.4.0)
+  - sign_in_with_apple (0.0.1):
+    - FlutterMacOS
+
+DEPENDENCIES:
+  - firebase_auth (from `Flutter/ephemeral/.symlinks/plugins/firebase_auth/macos`)
+  - firebase_core (from `Flutter/ephemeral/.symlinks/plugins/firebase_core/macos`)
+  - FlutterMacOS (from `Flutter/ephemeral`)
+  - google_sign_in_ios (from `Flutter/ephemeral/.symlinks/plugins/google_sign_in_ios/darwin`)
+  - sign_in_with_apple (from `Flutter/ephemeral/.symlinks/plugins/sign_in_with_apple/macos`)
+
+SPEC REPOS:
+  trunk:
+    - AppAuth
+    - AppCheckCore
+    - Firebase
+    - FirebaseAppCheckInterop
+    - FirebaseAuth
+    - FirebaseAuthInterop
+    - FirebaseCore
+    - FirebaseCoreExtension
+    - FirebaseCoreInternal
+    - GoogleSignIn
+    - GoogleUtilities
+    - GTMAppAuth
+    - GTMSessionFetcher
+    - PromisesObjC
+
+EXTERNAL SOURCES:
+  firebase_auth:
+    :path: Flutter/ephemeral/.symlinks/plugins/firebase_auth/macos
+  firebase_core:
+    :path: Flutter/ephemeral/.symlinks/plugins/firebase_core/macos
+  FlutterMacOS:
+    :path: Flutter/ephemeral
+  google_sign_in_ios:
+    :path: Flutter/ephemeral/.symlinks/plugins/google_sign_in_ios/darwin
+  sign_in_with_apple:
+    :path: Flutter/ephemeral/.symlinks/plugins/sign_in_with_apple/macos
+
+SPEC CHECKSUMS:
+  AppAuth: d4f13a8fe0baf391b2108511793e4b479691fb73
+  AppCheckCore: cc8fd0a3a230ddd401f326489c99990b013f0c4f
+  Firebase: 065f2bb395062046623036d8e6dc857bc2521d56
+  firebase_auth: 4437c13d38b14dc692a6593ab15514adbd78417b
+  firebase_core: e00200c307d299e4ffe12288aafeebdedeba38a6
+  FirebaseAppCheckInterop: 4bade10286cc977e516f75d2d8312cbdfa534789
+  FirebaseAuth: 3a39f6436c21ebfd7919b698228b4f89ff94c23b
+  FirebaseAuthInterop: f8f6ff72dc24621906497fbe5cf3c42ee815e59c
+  FirebaseCore: 428912f751178b06bef0a1793effeb4a5e09a9b8
+  FirebaseCoreExtension: e911052d59cd0da237a45d706fc0f81654f035c1
+  FirebaseCoreInternal: b321eafae5362113bc182956fafc9922cfc77b72
+  FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
+  google_sign_in_ios: 7411fab6948df90490dc4620ecbcabdc3ca04017
+  GoogleSignIn: ce8c89bb9b37fb624b92e7514cc67335d1e277e4
+  GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
+  GTMAppAuth: f69bd07d68cd3b766125f7e072c45d7340dea0de
+  GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
+  PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
+  sign_in_with_apple: a9e97e744e8edc36aefc2723111f652102a7a727
+
+PODFILE CHECKSUM: 54d867c82ac51cbd61b565781b9fada492027009
+
+COCOAPODS: 1.16.2

--- a/focusfeed/pubspec.lock
+++ b/focusfeed/pubspec.lock
@@ -236,10 +236,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -345,10 +345,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.9"
+    version: "0.7.10"
   typed_data:
     dependency: transitive
     description:

--- a/focusfeed/pubspec.yaml
+++ b/focusfeed/pubspec.yaml
@@ -24,4 +24,3 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
-

--- a/focusfeed/test/signup_test.dart
+++ b/focusfeed/test/signup_test.dart
@@ -1,0 +1,9 @@
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('signup test placeholder', () {
+    expect(true, true);
+
+  });
+}
+


### PR DESCRIPTION
Summary

This PR finishes the core Firebase Auth flow for email/password login and sign-up, adds visible auth error handling, and routes the app based on Firebase auth state.

What changed

Completed email/password account creation from the create account screen
Completed email/password login from the login screen
Added form validation for auth inputs before calling Firebase
Prevented duplicate auth submissions with loading/disabled states
Replaced swallowed Firebase auth errors with visible in-app messages
Added forgot-password support with password reset email flow
Added an auth gate in app startup using FirebaseAuth.authStateChanges()
Kept signed-in users in the authenticated flow on app reopen
Connected settings logout to real Firebase sign-out
Error handling covered

Invalid email
Empty fields
Weak password
Email already in use
Wrong password / invalid credential
User not found
Too many attempts
Network failure
Cancelled Google sign-in
Notes

This PR is mainly focused on auth flow completion and auth-state routing.
Automated auth test coverage is still minimal and should be expanded separately.
Manual testing

Create a new account with valid credentials
Verify invalid sign-up input does not submit
Log in with an existing user
Verify incorrect credentials show visible errors
Trigger password reset from the login screen
Close and reopen the app while signed in
Log out from settings and confirm return to the signed-out flow
Task https://github.com/CardinTran/FocusFeed/issues/22 and did not get the google issues or the keep sign up yet cs of issues with iOS and android