### PR TITLE
Task 57: Add unique username signup

### DIFF
--- a/focusfeed/lib/features/auth/screens/create_account_screen.dart
+++ b/focusfeed/lib/features/auth/screens/create_account_screen.dart
@@ -176,13 +176,10 @@ class _CreateAccountScreenState extends State<CreateAccountScreen> {
 
                   // Logo
                   Center(
-                    child: Container(
-                      height: 80,
+                    child: Image.asset(
+                      'web/ff-logo-transparent.png',
                       width: 80,
-                      decoration: BoxDecoration(
-                        color: Colors.white24,
-                        borderRadius: BorderRadius.circular(16),
-                      ),
+                      height: 80,
                     ),
                   ),
 

--- a/focusfeed/lib/features/auth/screens/create_account_screen.dart
+++ b/focusfeed/lib/features/auth/screens/create_account_screen.dart
@@ -1,9 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:focusfeed/features/auth/screens/app_entry_screen.dart';
 import 'package:focusfeed/features/auth/services/auth_service.dart';
+import 'package:focusfeed/features/auth/services/username_policy.dart';
 import 'package:focusfeed/features/profile/screens/profile_setup_screen.dart';
 
-/// Sign-up screen. Collects name, email, password, and confirm password,
+/// Sign-up screen. Collects username, email, password, and confirm password,
 /// validates them inline, then calls [AuthServices.signUpWithEmail].
 /// On success navigates to [ProfileSetupScreen] to complete onboarding.
 class CreateAccountScreen extends StatefulWidget {
@@ -20,12 +21,12 @@ class _CreateAccountScreenState extends State<CreateAccountScreen> {
   final _confirmPasswordFieldKey = GlobalKey<FormFieldState<String>>();
   bool _isLoading = false;
   String? _authError;
-  final nameController = TextEditingController();
+  final usernameController = TextEditingController();
   final emailController = TextEditingController();
   final passwordController = TextEditingController();
   final confirmPasswordController = TextEditingController();
 
-  final auth = AuthServices();
+  late final auth = AuthServices();
 
   bool _showPassword = false;
   bool _showConfirmPassword = false;
@@ -37,12 +38,7 @@ class _CreateAccountScreenState extends State<CreateAccountScreen> {
     return emailRegex.hasMatch(email);
   }
 
-  String? validateName(String? value) {
-    if (value == null || value.trim().isEmpty) {
-      return "Full Name cannot be empty";
-    }
-    return null;
-  }
+  String? validateUsername(String? value) => UsernamePolicy.validate(value);
 
   String? validateEmail(String? value) {
     final email = value?.trim() ?? '';
@@ -88,7 +84,7 @@ class _CreateAccountScreenState extends State<CreateAccountScreen> {
       await auth.signUpWithEmail(
         emailController.text.trim(),
         passwordController.text,
-        displayName: nameController.text,
+        username: usernameController.text,
       );
 
       if (!mounted) return;
@@ -139,7 +135,7 @@ class _CreateAccountScreenState extends State<CreateAccountScreen> {
 
   @override
   void dispose() {
-    nameController.dispose();
+    usernameController.dispose();
     emailController.dispose();
     passwordController.dispose();
     confirmPasswordController.dispose();
@@ -165,9 +161,18 @@ class _CreateAccountScreenState extends State<CreateAccountScreen> {
                     child: const Row(
                       mainAxisSize: MainAxisSize.min,
                       children: [
-                        Icon(Icons.arrow_back, color: Color.fromRGBO(133, 90, 251, 1), size: 18),
+                        Icon(
+                          Icons.arrow_back,
+                          color: Color.fromRGBO(133, 90, 251, 1),
+                          size: 18,
+                        ),
                         SizedBox(width: 4),
-                        Text("Back", style: TextStyle(color: Color.fromRGBO(133, 90, 251, 1))),
+                        Text(
+                          "Back",
+                          style: TextStyle(
+                            color: Color.fromRGBO(133, 90, 251, 1),
+                          ),
+                        ),
                       ],
                     ),
                   ),
@@ -199,12 +204,13 @@ class _CreateAccountScreenState extends State<CreateAccountScreen> {
 
                   const SizedBox(height: 30),
 
-                  // Full Name
+                  // Username
                   _InputField(
-                    hint: "Full Name",
-                    icon: Icons.person_outline,
-                    controller: nameController,
-                    validator: validateName,
+                    hint: "Username",
+                    icon: Icons.alternate_email,
+                    controller: usernameController,
+                    validator: validateUsername,
+                    textInputAction: TextInputAction.next,
                   ),
 
                   const SizedBox(height: 14),
@@ -216,6 +222,7 @@ class _CreateAccountScreenState extends State<CreateAccountScreen> {
                     keyboardType: TextInputType.emailAddress,
                     controller: emailController,
                     validator: validateEmail,
+                    textInputAction: TextInputAction.next,
                   ),
 
                   const SizedBox(height: 14),
@@ -227,13 +234,17 @@ class _CreateAccountScreenState extends State<CreateAccountScreen> {
                     obscure: !_showPassword,
                     controller: passwordController,
                     validator: validatePassword,
+                    textInputAction: TextInputAction.next,
                     suffixIcon: IconButton(
                       icon: Icon(
-                        _showPassword ? Icons.visibility_off_outlined : Icons.remove_red_eye_outlined,
+                        _showPassword
+                            ? Icons.visibility_off_outlined
+                            : Icons.remove_red_eye_outlined,
                         color: Colors.white38,
                         size: 20,
                       ),
-                      onPressed: () => setState(() => _showPassword = !_showPassword),
+                      onPressed: () =>
+                          setState(() => _showPassword = !_showPassword),
                     ),
                   ),
 
@@ -247,13 +258,18 @@ class _CreateAccountScreenState extends State<CreateAccountScreen> {
                     obscure: !_showConfirmPassword,
                     controller: confirmPasswordController,
                     validator: validateConfirmPassword,
+                    textInputAction: TextInputAction.done,
                     suffixIcon: IconButton(
                       icon: Icon(
-                        _showConfirmPassword ? Icons.visibility_off_outlined : Icons.remove_red_eye_outlined,
+                        _showConfirmPassword
+                            ? Icons.visibility_off_outlined
+                            : Icons.remove_red_eye_outlined,
                         color: Colors.white38,
                         size: 20,
                       ),
-                      onPressed: () => setState(() => _showConfirmPassword = !_showConfirmPassword),
+                      onPressed: () => setState(
+                        () => _showConfirmPassword = !_showConfirmPassword,
+                      ),
                     ),
                   ),
 
@@ -274,7 +290,9 @@ class _CreateAccountScreenState extends State<CreateAccountScreen> {
                     style: ElevatedButton.styleFrom(
                       backgroundColor: const Color.fromRGBO(133, 90, 251, 1),
                       minimumSize: const Size(double.infinity, 52),
-                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(12),
+                      ),
                     ),
                     onPressed: _isLoading ? null : _handleCreateAccount,
                     child: _isLoading
@@ -288,7 +306,11 @@ class _CreateAccountScreenState extends State<CreateAccountScreen> {
                           )
                         : const Text(
                             "Create Account",
-                            style: TextStyle(color: Colors.white, fontWeight: FontWeight.bold, fontSize: 16),
+                            style: TextStyle(
+                              color: Colors.white,
+                              fontWeight: FontWeight.bold,
+                              fontSize: 16,
+                            ),
                           ),
                   ),
 
@@ -301,7 +323,13 @@ class _CreateAccountScreenState extends State<CreateAccountScreen> {
                         const Expanded(child: Divider(color: Colors.white24)),
                         Padding(
                           padding: const EdgeInsets.symmetric(horizontal: 12),
-                          child: Text("Or continue with", style: TextStyle(color: Colors.white38, fontSize: 13)),
+                          child: Text(
+                            "Or continue with",
+                            style: TextStyle(
+                              color: Colors.white38,
+                              fontSize: 13,
+                            ),
+                          ),
                         ),
                         const Expanded(child: Divider(color: Colors.white24)),
                       ],
@@ -315,11 +343,23 @@ class _CreateAccountScreenState extends State<CreateAccountScreen> {
                         side: const BorderSide(color: Colors.white24),
                         minimumSize: const Size(double.infinity, 52),
                         padding: const EdgeInsets.symmetric(vertical: 14),
-                        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(12),
+                        ),
                       ),
                       onPressed: _isLoading ? null : _handleGoogleSignIn,
-                      icon: const Text("G", style: TextStyle(color: Colors.white, fontWeight: FontWeight.bold, fontSize: 16)),
-                      label: const Text("Google", style: TextStyle(color: Colors.white)),
+                      icon: const Text(
+                        "G",
+                        style: TextStyle(
+                          color: Colors.white,
+                          fontWeight: FontWeight.bold,
+                          fontSize: 16,
+                        ),
+                      ),
+                      label: const Text(
+                        "Google",
+                        style: TextStyle(color: Colors.white),
+                      ),
                     ),
 
                     const SizedBox(height: 20),
@@ -336,7 +376,10 @@ class _CreateAccountScreenState extends State<CreateAccountScreen> {
                           children: [
                             TextSpan(
                               text: "Login",
-                              style: TextStyle(color: Color.fromRGBO(133, 90, 251, 1), fontWeight: FontWeight.bold),
+                              style: TextStyle(
+                                color: Color.fromRGBO(133, 90, 251, 1),
+                                fontWeight: FontWeight.bold,
+                              ),
                             ),
                           ],
                         ),
@@ -362,7 +405,6 @@ class _InputField extends StatelessWidget {
   final TextInputType? keyboardType;
   final Widget? suffixIcon;
   final String? Function(String?)? validator;
-  final void Function(String)? onChanged;
   final TextInputAction? textInputAction;
 
   const _InputField({
@@ -374,7 +416,6 @@ class _InputField extends StatelessWidget {
     this.keyboardType,
     this.suffixIcon,
     this.validator,
-    this.onChanged,
     this.textInputAction,
   });
 
@@ -386,7 +427,6 @@ class _InputField extends StatelessWidget {
       obscureText: obscure,
       keyboardType: keyboardType,
       validator: validator,
-      onChanged: onChanged,
       textInputAction: textInputAction,
       autovalidateMode: AutovalidateMode.onUserInteraction,
       style: const TextStyle(color: Colors.white),
@@ -404,9 +444,7 @@ class _InputField extends StatelessWidget {
         ),
         focusedBorder: OutlineInputBorder(
           borderRadius: BorderRadius.circular(12),
-          borderSide: const BorderSide(
-            color: Color.fromRGBO(133, 90, 251, 1),
-          ),
+          borderSide: const BorderSide(color: Color.fromRGBO(133, 90, 251, 1)),
         ),
         errorBorder: OutlineInputBorder(
           borderRadius: BorderRadius.circular(12),

--- a/focusfeed/lib/features/auth/services/auth_service.dart
+++ b/focusfeed/lib/features/auth/services/auth_service.dart
@@ -1,6 +1,8 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/foundation.dart';
+import 'package:focusfeed/features/auth/services/username_policy.dart';
+import 'package:focusfeed/features/auth/services/username_reservation_service.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 
 /// Handles Firebase Authentication logic and creates the user's Firestore
@@ -9,6 +11,8 @@ class AuthServices {
   final FirebaseAuth auth = FirebaseAuth.instance;
   final FirebaseFirestore firestore = FirebaseFirestore.instance;
   final GoogleSignIn _googleSignIn = GoogleSignIn.instance;
+  late final UsernameReservationService _usernameReservations =
+      UsernameReservationService(firestore: firestore);
 
   /// Must be called once before using Google sign-in.
   Future<void> initGoogleSignIn() async {
@@ -40,28 +44,43 @@ class AuthServices {
   Future<UserCredential> signUpWithEmail(
     String email,
     String password, {
-    String? displayName,
+    required String username,
   }) async {
+    User? createdUser;
     try {
+      final usernameError = UsernamePolicy.validate(username);
+      if (usernameError != null) {
+        throw Exception(usernameError);
+      }
+
       final credential = await auth.createUserWithEmailAndPassword(
         email: email.trim(),
         password: password,
       );
 
       final user = credential.user;
+      createdUser = user;
       if (user != null) {
-        final trimmedName = displayName?.trim();
-        if (trimmedName != null && trimmedName.isNotEmpty) {
-          await user.updateDisplayName(trimmedName);
-          await user.reload();
-        }
-        await _createUserDocument(auth.currentUser ?? user);
+        final trimmedUsername = username.trim();
+        await user.updateDisplayName(trimmedUsername);
+        await user.reload();
+        await _createEmailUserDocument(
+          user: auth.currentUser ?? user,
+          username: username,
+        );
       }
 
       return credential;
+    } on UsernameTakenException {
+      await _deletePartiallyCreatedUser(createdUser);
+      throw Exception('That username is already taken.');
     } on FirebaseAuthException catch (e) {
       debugPrint('Sign up failed: ${e.code} - ${e.message}');
       throw Exception(_mapAuthError(e));
+    } on FirebaseException catch (e) {
+      await _deletePartiallyCreatedUser(createdUser);
+      debugPrint('Sign up profile setup failed: ${e.code} - ${e.message}');
+      throw Exception('Could not finish account setup. Please try again.');
     }
   }
 
@@ -142,6 +161,46 @@ class AuthServices {
         'displayNameLower': user.displayName?.toLowerCase() ?? '',
         'createdAt': FieldValue.serverTimestamp(),
       });
+    }
+  }
+
+  Future<void> _createEmailUserDocument({
+    required User user,
+    required String username,
+  }) async {
+    final trimmedUsername = username.trim();
+    final normalizedUsername = UsernamePolicy.normalize(username);
+    final userDoc = firestore.collection('users').doc(user.uid);
+
+    await firestore.runTransaction((transaction) async {
+      await _usernameReservations.reserveUsernameInTransaction(
+        transaction,
+        uid: user.uid,
+        username: username,
+      );
+
+      transaction.set(userDoc, {
+        'uid': user.uid,
+        'email': user.email,
+        'displayName': trimmedUsername,
+        'displayNameLower': normalizedUsername,
+        'username': trimmedUsername,
+        'usernameLower': normalizedUsername,
+        'createdAt': FieldValue.serverTimestamp(),
+        'updatedAt': FieldValue.serverTimestamp(),
+      });
+    });
+  }
+
+  Future<void> _deletePartiallyCreatedUser(User? user) async {
+    if (user == null) return;
+
+    try {
+      await user.delete();
+    } catch (e) {
+      debugPrint('Failed to clean up incomplete signup user: $e');
+    } finally {
+      await auth.signOut();
     }
   }
 }

--- a/focusfeed/lib/features/auth/services/username_policy.dart
+++ b/focusfeed/lib/features/auth/services/username_policy.dart
@@ -1,0 +1,50 @@
+import 'package:profanity_filter/profanity_filter.dart';
+
+class UsernamePolicy {
+  static final RegExp _allowedPattern = RegExp(r'^[a-zA-Z0-9_]+$');
+  static final RegExp _startsWithLetterPattern = RegExp(r'^[a-zA-Z]');
+  static final ProfanityFilter _profanityFilter = ProfanityFilter();
+
+  static const Set<String> _reservedTerms = {
+    'admin',
+    'administrator',
+    'moderator',
+    'support',
+    'official',
+    'focusfeed',
+  };
+
+  static String normalize(String username) => username.trim().toLowerCase();
+
+  static String? validate(String? value) {
+    final username = value?.trim() ?? '';
+    final normalized = normalize(username);
+
+    if (username.isEmpty) {
+      return 'Username cannot be empty';
+    }
+    if (username.length < 6 || username.length > 20) {
+      return 'Username must be 6-20 characters';
+    }
+    if (!_startsWithLetterPattern.hasMatch(username)) {
+      return 'Username must start with a letter';
+    }
+    if (!_allowedPattern.hasMatch(username)) {
+      return 'Use only letters, numbers, and underscores';
+    }
+    if (username.contains('__')) {
+      return 'Username cannot contain consecutive underscores';
+    }
+    if (username.endsWith('_')) {
+      return 'Username cannot end with an underscore';
+    }
+    if (_reservedTerms.any(normalized.contains)) {
+      return 'Please choose a different username';
+    }
+    if (_profanityFilter.hasProfanity(normalized)) {
+      return 'Please choose a different username';
+    }
+
+    return null;
+  }
+}

--- a/focusfeed/lib/features/auth/services/username_reservation_service.dart
+++ b/focusfeed/lib/features/auth/services/username_reservation_service.dart
@@ -1,0 +1,52 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:focusfeed/features/auth/services/username_policy.dart';
+
+class UsernameTakenException implements Exception {}
+
+class UsernameReservationService {
+  UsernameReservationService({FirebaseFirestore? firestore})
+    : _firestore = firestore ?? FirebaseFirestore.instance;
+
+  final FirebaseFirestore _firestore;
+
+  Future<void> reserveUsername({
+    required String uid,
+    required String username,
+  }) async {
+    await _firestore.runTransaction((transaction) {
+      return reserveUsernameInTransaction(
+        transaction,
+        uid: uid,
+        username: username,
+      );
+    });
+  }
+
+  Future<void> reserveUsernameInTransaction(
+    Transaction transaction, {
+    required String uid,
+    required String username,
+  }) async {
+    final usernameError = UsernamePolicy.validate(username);
+    if (usernameError != null) {
+      throw ArgumentError(usernameError);
+    }
+
+    final normalizedUsername = UsernamePolicy.normalize(username);
+    final usernameDoc = _firestore
+        .collection('usernames')
+        .doc(normalizedUsername);
+    final usernameSnapshot = await transaction.get(usernameDoc);
+
+    if (usernameSnapshot.exists) {
+      throw UsernameTakenException();
+    }
+
+    transaction.set(usernameDoc, {
+      'uid': uid,
+      'username': username.trim(),
+      'usernameLower': normalizedUsername,
+      'createdAt': FieldValue.serverTimestamp(),
+    });
+  }
+}

--- a/focusfeed/lib/features/friends/friend_model.dart
+++ b/focusfeed/lib/features/friends/friend_model.dart
@@ -6,14 +6,23 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 class UserResult {
   final String uid;
   final String displayName;
+  final String username;
 
-  const UserResult({required this.uid, required this.displayName});
+  const UserResult({
+    required this.uid,
+    required this.displayName,
+    required this.username,
+  });
 
   factory UserResult.fromDoc(DocumentSnapshot doc) {
     final data = doc.data() as Map<String, dynamic>;
+    final username = data['username'] as String? ?? '';
     return UserResult(
       uid: doc.id,
-      displayName: data['displayName'] as String? ?? 'Unknown',
+      displayName:
+          data['displayName'] as String? ??
+          (username.isEmpty ? 'Unknown' : username),
+      username: username,
     );
   }
 }
@@ -51,19 +60,25 @@ class FriendRequest {
 class Friend {
   final String uid;
   final String displayName;
+  final String username;
   final DateTime? addedAt;
 
   const Friend({
     required this.uid,
     required this.displayName,
+    this.username = '',
     this.addedAt,
   });
 
   factory Friend.fromDoc(DocumentSnapshot doc) {
     final data = doc.data() as Map<String, dynamic>;
+    final username = data['username'] as String? ?? '';
     return Friend(
       uid: data['uid'] as String,
-      displayName: data['displayName'] as String? ?? 'Unknown',
+      displayName:
+          data['displayName'] as String? ??
+          (username.isEmpty ? 'Unknown' : username),
+      username: username,
       addedAt: (data['addedAt'] as Timestamp?)?.toDate(),
     );
   }

--- a/focusfeed/lib/features/friends/friend_profile_screen.dart
+++ b/focusfeed/lib/features/friends/friend_profile_screen.dart
@@ -10,38 +10,42 @@ class FriendProfileScreen extends StatelessWidget {
 
   const FriendProfileScreen({super.key, required this.friend});
 
-  static const Color _bg     = Color(0xFF0B0F2A);
-  static const Color _card   = Color(0xFF151A3B);
+  static const Color _bg = Color(0xFF0B0F2A);
+  static const Color _card = Color(0xFF151A3B);
   static const Color _accent = Color(0xFF855AFB);
   static const Color _border = Color(0x12FFFFFF);
 
   @override
   Widget build(BuildContext context) {
-    final initials = friend.displayName
-        .split(' ')
-        .where((w) => w.isNotEmpty)
-        .take(2)
-        .map((w) => w[0].toUpperCase())
-        .join();
-
     return Scaffold(
       backgroundColor: _bg,
       appBar: AppBar(
         backgroundColor: const Color(0xFF12182F),
-        title: Text(friend.displayName,
-            style: const TextStyle(color: Colors.white)),
+        title: Text(
+          friend.displayName,
+          style: const TextStyle(color: Colors.white),
+        ),
         iconTheme: const IconThemeData(color: Colors.white),
       ),
-      body: FutureBuilder<DocumentSnapshot>(
-        future: FirebaseFirestore.instance
+      body: StreamBuilder<DocumentSnapshot>(
+        stream: FirebaseFirestore.instance
             .collection('users')
             .doc(friend.uid)
-            .get(),
+            .snapshots(),
         builder: (context, snap) {
           final data = snap.data?.data() as Map<String, dynamic>?;
+          final displayName =
+              data?['displayName'] as String? ?? friend.displayName;
+          final username = data?['username'] as String? ?? friend.username;
           final school = data?['school'] as String? ?? '';
           final courses = List<String>.from(data?['selectedCourses'] ?? []);
           final subjects = List<String>.from(data?['selectedSubjects'] ?? []);
+          final initials = displayName
+              .split(' ')
+              .where((w) => w.isNotEmpty)
+              .take(2)
+              .map((w) => w[0].toUpperCase())
+              .join();
 
           return SingleChildScrollView(
             padding: const EdgeInsets.all(20),
@@ -50,31 +54,53 @@ class FriendProfileScreen extends StatelessWidget {
               children: [
                 // Avatar + name
                 Center(
-                  child: Column(children: [
-                    const SizedBox(height: 8),
-                    CircleAvatar(
-                      radius: 40,
-                      backgroundColor: _accent,
-                      child: Text(initials,
+                  child: Column(
+                    children: [
+                      const SizedBox(height: 8),
+                      CircleAvatar(
+                        radius: 40,
+                        backgroundColor: _accent,
+                        child: Text(
+                          initials,
                           style: const TextStyle(
-                              color: Colors.white,
-                              fontSize: 24,
-                              fontWeight: FontWeight.w600)),
-                    ),
-                    const SizedBox(height: 12),
-                    Text(friend.displayName,
-                        style: const TextStyle(
                             color: Colors.white,
-                            fontSize: 20,
-                            fontWeight: FontWeight.w600)),
-                    if (school.isNotEmpty) ...[
-                      const SizedBox(height: 4),
-                      Text(school,
+                            fontSize: 24,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                      ),
+                      const SizedBox(height: 12),
+                      Text(
+                        displayName,
+                        style: const TextStyle(
+                          color: Colors.white,
+                          fontSize: 20,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                      if (username.isNotEmpty) ...[
+                        const SizedBox(height: 4),
+                        Text(
+                          '@$username',
                           style: const TextStyle(
-                              color: Colors.white54, fontSize: 13)),
+                            color: Colors.white54,
+                            fontSize: 13,
+                          ),
+                        ),
+                      ],
+                      if (school.isNotEmpty) ...[
+                        const SizedBox(height: 4),
+                        Text(
+                          school,
+                          style: const TextStyle(
+                            color: Colors.white54,
+                            fontSize: 13,
+                          ),
+                        ),
+                      ],
+                      const SizedBox(height: 24),
                     ],
-                    const SizedBox(height: 24),
-                  ]),
+                  ),
                 ),
 
                 // Courses
@@ -105,20 +131,24 @@ class FriendProfileScreen extends StatelessWidget {
                 _sectionLabel('Study Content'),
                 const SizedBox(height: 12),
                 StreamBuilder<List<FeedItem>>(
-                  stream: ImportRepository()
-                      .streamAllFeedItemsForUser(friend.uid),
+                  stream: ImportRepository().streamAllFeedItemsForUser(
+                    friend.uid,
+                  ),
                   builder: (context, snap) {
                     if (snap.connectionState == ConnectionState.waiting) {
                       return const Center(
-                          child: CircularProgressIndicator(color: _accent));
+                        child: CircularProgressIndicator(color: _accent),
+                      );
                     }
                     final items = snap.data ?? [];
                     if (items.isEmpty) {
                       return const Center(
                         child: Padding(
                           padding: EdgeInsets.only(top: 16),
-                          child: Text('No study content yet.',
-                              style: TextStyle(color: Colors.white54)),
+                          child: Text(
+                            'No study content yet.',
+                            style: TextStyle(color: Colors.white54),
+                          ),
                         ),
                       );
                     }
@@ -130,12 +160,12 @@ class FriendProfileScreen extends StatelessWidget {
                       grouped.putIfAbsent(key, () => []).add(item);
                     }
 
-	                    return Column(
-	                      children: grouped.entries.map((entry) {
-	                        final cards = entry.value;
-	                        return _deckCard(context, entry.key, cards);
-	                      }).toList(),
-	                    );
+                    return Column(
+                      children: grouped.entries.map((entry) {
+                        final cards = entry.value;
+                        return _deckCard(context, entry.key, cards);
+                      }).toList(),
+                    );
                   },
                 ),
               ],
@@ -147,36 +177,43 @@ class FriendProfileScreen extends StatelessWidget {
   }
 
   Widget _sectionLabel(String label) => Text(
-        label.toUpperCase(),
-        style: const TextStyle(
-            color: Color(0x40FFFFFF),
-            fontSize: 11,
-            fontWeight: FontWeight.w600,
-            letterSpacing: 0.8),
-      );
+    label.toUpperCase(),
+    style: const TextStyle(
+      color: Color(0x40FFFFFF),
+      fontSize: 11,
+      fontWeight: FontWeight.w600,
+      letterSpacing: 0.8,
+    ),
+  );
 
   Widget _chip(String label) => Container(
-        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-        decoration: BoxDecoration(
-          color: _accent.withValues(alpha: 0.12),
-          borderRadius: BorderRadius.circular(20),
-          border: Border.all(color: _accent.withValues(alpha: 0.3)),
-        ),
-        child: Text(label,
-            style: const TextStyle(
-                color: _accent, fontSize: 13, fontWeight: FontWeight.w500)),
-      );
+    padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+    decoration: BoxDecoration(
+      color: _accent.withValues(alpha: 0.12),
+      borderRadius: BorderRadius.circular(20),
+      border: Border.all(color: _accent.withValues(alpha: 0.3)),
+    ),
+    child: Text(
+      label,
+      style: const TextStyle(
+        color: _accent,
+        fontSize: 13,
+        fontWeight: FontWeight.w500,
+      ),
+    ),
+  );
 
   Widget _deckCard(
-      BuildContext context, String importId, List<FeedItem> cards) {
+    BuildContext context,
+    String importId,
+    List<FeedItem> cards,
+  ) {
     return GestureDetector(
       onTap: () => Navigator.push(
         context,
         MaterialPageRoute(
-          builder: (_) => FriendDeckScreen(
-            friendName: friend.displayName,
-            cards: cards,
-          ),
+          builder: (_) =>
+              FriendDeckScreen(friendName: friend.displayName, cards: cards),
         ),
       ),
       child: Container(
@@ -187,35 +224,41 @@ class FriendProfileScreen extends StatelessWidget {
           borderRadius: BorderRadius.circular(14),
           border: Border.all(color: _border),
         ),
-        child: Row(children: [
-          Container(
-            width: 40,
-            height: 40,
-            decoration: BoxDecoration(
-              color: _accent.withValues(alpha: 0.15),
-              borderRadius: BorderRadius.circular(10),
+        child: Row(
+          children: [
+            Container(
+              width: 40,
+              height: 40,
+              decoration: BoxDecoration(
+                color: _accent.withValues(alpha: 0.15),
+                borderRadius: BorderRadius.circular(10),
+              ),
+              child: const Icon(Icons.style_outlined, color: _accent, size: 20),
             ),
-            child: const Icon(Icons.style_outlined, color: _accent, size: 20),
-          ),
-          const SizedBox(width: 14),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text('Flashcard Deck',
+            const SizedBox(width: 14),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Flashcard Deck',
                     style: const TextStyle(
-                        color: Colors.white,
-                        fontSize: 14,
-                        fontWeight: FontWeight.w600)),
-                const SizedBox(height: 2),
-                Text('${cards.length} cards',
-                    style: const TextStyle(
-                        color: Colors.white54, fontSize: 12)),
-              ],
+                      color: Colors.white,
+                      fontSize: 14,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    '${cards.length} cards',
+                    style: const TextStyle(color: Colors.white54, fontSize: 12),
+                  ),
+                ],
+              ),
             ),
-          ),
-          const Icon(Icons.chevron_right, color: Colors.white24, size: 18),
-        ]),
+            const Icon(Icons.chevron_right, color: Colors.white24, size: 18),
+          ],
+        ),
       ),
     );
   }

--- a/focusfeed/lib/features/friends/friend_repository.dart
+++ b/focusfeed/lib/features/friends/friend_repository.dart
@@ -9,26 +9,32 @@ class FriendRepository {
     if (query.isEmpty) return [];
     final lower = query.toLowerCase();
     try {
-	      final snap = await _db
-	          .collection('users')
-	          .where('displayNameLower', isGreaterThanOrEqualTo: lower)
-	          .where('displayNameLower', isLessThan: '$lower\uf8ff')
-	          .limit(10)
-	          .get();
-	      return snap.docs.map(UserResult.fromDoc).toList();
-	    } catch (e) {
-	      debugPrint('SEARCH ERROR: $e');
-	      return [];
-	    }
+      final snap = await _db
+          .collection('users')
+          .where('usernameLower', isGreaterThanOrEqualTo: lower)
+          .where('usernameLower', isLessThan: '$lower\uf8ff')
+          .limit(10)
+          .get();
+      return snap.docs.map(UserResult.fromDoc).toList();
+    } catch (e) {
+      debugPrint('SEARCH ERROR: $e');
+      return [];
+    }
   }
 
   // Fetches sender's name then stores it so receiver sees it correctly
-  Future<void> sendRequest(String fromUid, String toUid, String toDisplayName) async {
+  Future<void> sendRequest(
+    String fromUid,
+    String toUid,
+    String toDisplayName,
+  ) async {
     final fromDisplayName = await getDisplayName(fromUid);
+    final fromUsername = await getUsername(fromUid);
     await _db.collection('friendRequests').add({
       'fromUid': fromUid,
       'toUid': toUid,
       'fromDisplayName': fromDisplayName,
+      'fromUsername': fromUsername,
       'toDisplayName': toDisplayName,
       'status': 'pending',
       'createdAt': FieldValue.serverTimestamp(),
@@ -45,26 +51,27 @@ class FriendRepository {
     final batch = _db.batch();
     final ts = FieldValue.serverTimestamp();
 
-    batch.update(
-      _db.collection('friendRequests').doc(requestId),
-      {'status': 'accepted'},
-    );
-    batch.set(
-      _db.doc('friends/$currentUid/friendsList/$fromUid'),
-      {'uid': fromUid, 'displayName': fromDisplayName, 'addedAt': ts},
-    );
-    batch.set(
-      _db.doc('friends/$fromUid/friendsList/$currentUid'),
-      {'uid': currentUid, 'displayName': currentDisplayName, 'addedAt': ts},
-    );
+    batch.update(_db.collection('friendRequests').doc(requestId), {
+      'status': 'accepted',
+    });
+    batch.set(_db.doc('friends/$currentUid/friendsList/$fromUid'), {
+      'uid': fromUid,
+      'displayName': fromDisplayName,
+      'addedAt': ts,
+    });
+    batch.set(_db.doc('friends/$fromUid/friendsList/$currentUid'), {
+      'uid': currentUid,
+      'displayName': currentDisplayName,
+      'addedAt': ts,
+    });
 
     await batch.commit();
   }
 
   Future<void> declineRequest(String requestId) async {
-    await _db.collection('friendRequests').doc(requestId).update(
-      {'status': 'declined'},
-    );
+    await _db.collection('friendRequests').doc(requestId).update({
+      'status': 'declined',
+    });
   }
 
   Future<void> removeFriend(String currentUid, String friendUid) async {
@@ -92,6 +99,13 @@ class FriendRepository {
         .map((s) => s.docs.map(Friend.fromDoc).toList());
   }
 
+  Stream<UserResult?> userProfile(String uid) {
+    return _db.collection('users').doc(uid).snapshots().map((doc) {
+      if (!doc.exists) return null;
+      return UserResult.fromDoc(doc);
+    });
+  }
+
   Future<bool> requestExists(String fromUid, String toUid) async {
     final snap = await _db
         .collection('friendRequests')
@@ -104,6 +118,14 @@ class FriendRepository {
 
   Future<String> getDisplayName(String uid) async {
     final doc = await _db.collection('users').doc(uid).get();
-    return doc.data()?['displayName'] as String? ?? 'Unknown';
+    final data = doc.data();
+    return data?['displayName'] as String? ??
+        data?['username'] as String? ??
+        'Unknown';
+  }
+
+  Future<String> getUsername(String uid) async {
+    final doc = await _db.collection('users').doc(uid).get();
+    return doc.data()?['username'] as String? ?? '';
   }
 }

--- a/focusfeed/lib/features/friends/friend_service.dart
+++ b/focusfeed/lib/features/friends/friend_service.dart
@@ -23,18 +23,18 @@ class FriendService {
 
   // Accept incoming request
   Future<void> acceptRequest(FriendRequest request) async {
-  final myName = await _repo.getDisplayName(_uid);
-  final fromName = request.fromDisplayName.isNotEmpty
-      ? request.fromDisplayName
-      : await _repo.getDisplayName(request.fromUid);
-  await _repo.acceptRequest(
-    request.id,
-    request.fromUid,
-    fromName,
-    _uid,
-    myName,
-  );
-}
+    final myName = await _repo.getDisplayName(_uid);
+    final fromName = request.fromDisplayName.isNotEmpty
+        ? request.fromDisplayName
+        : await _repo.getDisplayName(request.fromUid);
+    await _repo.acceptRequest(
+      request.id,
+      request.fromUid,
+      fromName,
+      _uid,
+      myName,
+    );
+  }
 
   // Decline incoming request
   Future<void> declineRequest(String requestId) async {
@@ -45,14 +45,16 @@ class FriendService {
   Future<void> removeFriend(String friendUid) async {
     await _repo.removeFriend(_uid, friendUid);
   }
+
   Future<List<UserResult>> searchUsers(String query) async {
-  return _repo.searchUsers(query);
-}
+    return _repo.searchUsers(query);
+  }
+
+  Stream<UserResult?> userProfile(String uid) => _repo.userProfile(uid);
+
   // Live stream of pending requests
-  Stream<List<FriendRequest>> pendingRequests() =>
-      _repo.pendingRequests(_uid);
+  Stream<List<FriendRequest>> pendingRequests() => _repo.pendingRequests(_uid);
 
   // Live stream of friends list
-  Stream<List<Friend>> friendsList() =>
-      _repo.friendsList(_uid);
+  Stream<List<Friend>> friendsList() => _repo.friendsList(_uid);
 }

--- a/focusfeed/lib/features/friends/friends_screen.dart
+++ b/focusfeed/lib/features/friends/friends_screen.dart
@@ -11,8 +11,8 @@ class FriendsScreen extends StatefulWidget {
 }
 
 class _FriendsScreenState extends State<FriendsScreen> {
-  static const Color _bg     = Color(0xFF0B0F2A);
-  static const Color _card   = Color(0xFF151A3B);
+  static const Color _bg = Color(0xFF0B0F2A);
+  static const Color _card = Color(0xFF151A3B);
   static const Color _accent = Color(0xFF855AFB);
   static const Color _border = Color(0x12FFFFFF);
 
@@ -29,7 +29,12 @@ class _FriendsScreenState extends State<FriendsScreen> {
     }
     setState(() => _searching = true);
     final results = await _service.searchUsers(query);
-    if (mounted) setState(() { _searchResults = results; _searching = false; });
+    if (mounted) {
+      setState(() {
+        _searchResults = results;
+        _searching = false;
+      });
+    }
   }
 
   Future<void> _sendRequest(UserResult user) async {
@@ -64,92 +69,111 @@ class _FriendsScreenState extends State<FriendsScreen> {
             ],
           ),
         ),
-        body: Column(children: [
-          // Search bar
-          Padding(
-            padding: const EdgeInsets.all(12),
-            child: TextField(
-              controller: _searchController,
-              onChanged: _onSearchChanged,
-              style: const TextStyle(color: Colors.white),
-              decoration: InputDecoration(
-                hintText: 'Search by username...',
-                hintStyle: const TextStyle(color: Colors.white38),
-                prefixIcon: const Icon(Icons.search, color: Colors.white38),
-                suffixIcon: _searching
-                    ? const Padding(
-                        padding: EdgeInsets.all(12),
-                        child: SizedBox(
-                          width: 16, height: 16,
-                          child: CircularProgressIndicator(
-                            strokeWidth: 2,
-                            color: _accent,
+        body: Column(
+          children: [
+            // Search bar
+            Padding(
+              padding: const EdgeInsets.all(12),
+              child: TextField(
+                controller: _searchController,
+                onChanged: _onSearchChanged,
+                style: const TextStyle(color: Colors.white),
+                decoration: InputDecoration(
+                  hintText: 'Search by username...',
+                  hintStyle: const TextStyle(color: Colors.white38),
+                  prefixIcon: const Icon(Icons.search, color: Colors.white38),
+                  suffixIcon: _searching
+                      ? const Padding(
+                          padding: EdgeInsets.all(12),
+                          child: SizedBox(
+                            width: 16,
+                            height: 16,
+                            child: CircularProgressIndicator(
+                              strokeWidth: 2,
+                              color: _accent,
+                            ),
                           ),
+                        )
+                      : null,
+                  filled: true,
+                  fillColor: _card,
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(12),
+                    borderSide: const BorderSide(color: _border),
+                  ),
+                  enabledBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(12),
+                    borderSide: const BorderSide(color: _border),
+                  ),
+                  focusedBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(12),
+                    borderSide: const BorderSide(color: _accent, width: 1.4),
+                  ),
+                  isDense: true,
+                ),
+              ),
+            ),
+
+            // Search results
+            if (_searchResults.isNotEmpty)
+              Container(
+                margin: const EdgeInsets.symmetric(horizontal: 12),
+                decoration: BoxDecoration(
+                  color: _card,
+                  border: Border.all(color: _border),
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: ListView.separated(
+                  shrinkWrap: true,
+                  physics: const NeverScrollableScrollPhysics(),
+                  itemCount: _searchResults.length,
+                  separatorBuilder: (_, _) =>
+                      const Divider(height: 1, color: Color(0x12FFFFFF)),
+                  itemBuilder: (_, i) {
+                    final user = _searchResults[i];
+                    return ListTile(
+                      dense: true,
+                      leading: CircleAvatar(
+                        backgroundColor: _accent.withValues(alpha: 0.2),
+                        child: const Icon(
+                          Icons.person,
+                          size: 18,
+                          color: _accent,
                         ),
-                      )
-                    : null,
-                filled: true,
-                fillColor: _card,
-                border: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(12),
-                  borderSide: const BorderSide(color: _border),
+                      ),
+                      title: Text(
+                        user.displayName,
+                        style: const TextStyle(color: Colors.white),
+                      ),
+                      subtitle: user.username.isEmpty
+                          ? null
+                          : Text(
+                              '@${user.username}',
+                              style: const TextStyle(
+                                color: Colors.white54,
+                                fontSize: 12,
+                              ),
+                            ),
+                      trailing: TextButton(
+                        onPressed: () => _sendRequest(user),
+                        child: const Text(
+                          'Add',
+                          style: TextStyle(color: _accent),
+                        ),
+                      ),
+                    );
+                  },
                 ),
-                enabledBorder: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(12),
-                  borderSide: const BorderSide(color: _border),
-                ),
-                focusedBorder: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(12),
-                  borderSide: const BorderSide(color: _accent, width: 1.4),
-                ),
-                isDense: true,
+              ),
+
+            // Tab views
+            Expanded(
+              child: TabBarView(
+                children: [_buildFriendsList(), _buildPendingList()],
               ),
             ),
-          ),
-
-          // Search results
-          if (_searchResults.isNotEmpty)
-            Container(
-              margin: const EdgeInsets.symmetric(horizontal: 12),
-              decoration: BoxDecoration(
-                color: _card,
-                border: Border.all(color: _border),
-                borderRadius: BorderRadius.circular(12),
-              ),
-              child: ListView.separated(
-                shrinkWrap: true,
-                physics: const NeverScrollableScrollPhysics(),
-                itemCount: _searchResults.length,
-	                separatorBuilder: (_, _) => const Divider(
-	                  height: 1, color: Color(0x12FFFFFF)),
-                itemBuilder: (_, i) {
-                  final user = _searchResults[i];
-                  return ListTile(
-                    dense: true,
-                    leading: CircleAvatar(
-	                      backgroundColor: _accent.withValues(alpha: 0.2),
-                      child: const Icon(Icons.person, size: 18, color: _accent),
-                    ),
-                    title: Text(user.displayName,
-                        style: const TextStyle(color: Colors.white)),
-                    trailing: TextButton(
-                      onPressed: () => _sendRequest(user),
-                      child: const Text('Add',
-                          style: TextStyle(color: _accent)),
-                    ),
-                  );
-                },
-              ),
-            ),
-
-          // Tab views
-          Expanded(
-            child: TabBarView(children: [
-              _buildFriendsList(),
-              _buildPendingList(),
-            ]),
-          ),
-        ]),
+          ],
+        ),
       ),
     );
   }
@@ -164,31 +188,56 @@ class _FriendsScreenState extends State<FriendsScreen> {
         final friends = snap.data ?? [];
         if (friends.isEmpty) {
           return const Center(
-            child: Text('No friends yet.',
-                style: TextStyle(color: Colors.white54)));
+            child: Text(
+              'No friends yet.',
+              style: TextStyle(color: Colors.white54),
+            ),
+          );
         }
         return ListView.builder(
           itemCount: friends.length,
           itemBuilder: (_, i) {
             final f = friends[i];
-            return ListTile(
-              onTap: () => Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (_) => FriendProfileScreen(friend: f),
-                ),
-              ),
-              leading: CircleAvatar(
-	                backgroundColor: _accent.withValues(alpha: 0.2),
-                child: const Icon(Icons.person, color: _accent),
-              ),
-              title: Text(f.displayName,
-                  style: const TextStyle(color: Colors.white)),
-              trailing: IconButton(
-                icon: const Icon(Icons.person_remove_outlined,
-                    color: Colors.white38),
-                onPressed: () => _service.removeFriend(f.uid),
-              ),
+            return StreamBuilder<UserResult?>(
+              stream: _service.userProfile(f.uid),
+              builder: (context, profileSnap) {
+                final profile = profileSnap.data;
+                final displayName = profile?.displayName ?? f.displayName;
+                final username = profile?.username ?? f.username;
+
+                return ListTile(
+                  onTap: () => Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => FriendProfileScreen(friend: f),
+                    ),
+                  ),
+                  leading: CircleAvatar(
+                    backgroundColor: _accent.withValues(alpha: 0.2),
+                    child: const Icon(Icons.person, color: _accent),
+                  ),
+                  title: Text(
+                    displayName,
+                    style: const TextStyle(color: Colors.white),
+                  ),
+                  subtitle: username.isEmpty
+                      ? null
+                      : Text(
+                          '@$username',
+                          style: const TextStyle(
+                            color: Colors.white54,
+                            fontSize: 12,
+                          ),
+                        ),
+                  trailing: IconButton(
+                    icon: const Icon(
+                      Icons.person_remove_outlined,
+                      color: Colors.white38,
+                    ),
+                    onPressed: () => _service.removeFriend(f.uid),
+                  ),
+                );
+              },
             );
           },
         );
@@ -206,35 +255,62 @@ class _FriendsScreenState extends State<FriendsScreen> {
         final requests = snap.data ?? [];
         if (requests.isEmpty) {
           return const Center(
-            child: Text('No pending requests.',
-                style: TextStyle(color: Colors.white54)));
+            child: Text(
+              'No pending requests.',
+              style: TextStyle(color: Colors.white54),
+            ),
+          );
         }
         return ListView.builder(
           itemCount: requests.length,
           itemBuilder: (_, i) {
             final r = requests[i];
-            return ListTile(
-              leading: CircleAvatar(
-	                backgroundColor: _accent.withValues(alpha: 0.2),
-                child: const Icon(Icons.person_add, color: _accent),
-              ),
-              title: Text(r.fromDisplayName,
-                  style: const TextStyle(color: Colors.white)),
-              trailing: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  IconButton(
-                    icon: const Icon(Icons.check_circle_outline,
-                        color: Colors.greenAccent),
-                    onPressed: () => _service.acceptRequest(r),
+            return StreamBuilder<UserResult?>(
+              stream: _service.userProfile(r.fromUid),
+              builder: (context, profileSnap) {
+                final profile = profileSnap.data;
+                final displayName = profile?.displayName ?? r.fromDisplayName;
+                final username = profile?.username ?? '';
+
+                return ListTile(
+                  leading: CircleAvatar(
+                    backgroundColor: _accent.withValues(alpha: 0.2),
+                    child: const Icon(Icons.person_add, color: _accent),
                   ),
-                  IconButton(
-                    icon: const Icon(Icons.cancel_outlined,
-                        color: Colors.redAccent),
-                    onPressed: () => _service.declineRequest(r.id),
+                  title: Text(
+                    displayName,
+                    style: const TextStyle(color: Colors.white),
                   ),
-                ],
-              ),
+                  subtitle: username.isEmpty
+                      ? null
+                      : Text(
+                          '@$username',
+                          style: const TextStyle(
+                            color: Colors.white54,
+                            fontSize: 12,
+                          ),
+                        ),
+                  trailing: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      IconButton(
+                        icon: const Icon(
+                          Icons.check_circle_outline,
+                          color: Colors.greenAccent,
+                        ),
+                        onPressed: () => _service.acceptRequest(r),
+                      ),
+                      IconButton(
+                        icon: const Icon(
+                          Icons.cancel_outlined,
+                          color: Colors.redAccent,
+                        ),
+                        onPressed: () => _service.declineRequest(r.id),
+                      ),
+                    ],
+                  ),
+                );
+              },
             );
           },
         );

--- a/focusfeed/lib/features/profile/screens/profile_screen.dart
+++ b/focusfeed/lib/features/profile/screens/profile_screen.dart
@@ -9,11 +9,11 @@ import 'package:focusfeed/features/settings/settings_screen.dart';
 class ProfileScreen extends StatelessWidget {
   const ProfileScreen({super.key});
 
-  static const Color _bg     = Color(0xFF0B0F2A);
-  static const Color _card   = Color(0xFF151A3B);
+  static const Color _bg = Color(0xFF0B0F2A);
+  static const Color _card = Color(0xFF151A3B);
   static const Color _accent = Color(0xFF855AFB);
   static const Color _primary = Colors.white;
-  static const Color _muted  = Color(0x70FFFFFF);
+  static const Color _muted = Color(0x70FFFFFF);
   static const Color _divider = Color(0x12FFFFFF);
 
   @override
@@ -21,11 +21,17 @@ class ProfileScreen extends StatelessWidget {
     final user = FirebaseAuth.instance.currentUser;
     final uid = user?.uid ?? '';
 
-    return FutureBuilder<DocumentSnapshot>(
-      future: FirebaseFirestore.instance.collection('users').doc(uid).get(),
+    return StreamBuilder<DocumentSnapshot>(
+      stream: FirebaseFirestore.instance
+          .collection('users')
+          .doc(uid)
+          .snapshots(),
       builder: (context, snap) {
         final data = snap.data?.data() as Map<String, dynamic>?;
-        final name = data?['displayName'] as String? ?? 'No name set';
+        final username = data?['username'] as String? ?? '';
+        final name =
+            data?['displayName'] as String? ??
+            (username.isEmpty ? 'No name set' : username);
         final email = user?.email ?? '';
         final initials = name
             .split(' ')
@@ -43,31 +49,45 @@ class ProfileScreen extends StatelessWidget {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Center(
-                    child: Column(children: [
-                      const SizedBox(height: 16),
-                      CircleAvatar(
-                        radius: 36,
-                        backgroundColor: _accent,
-                        child: Text(
-                          initials,
+                    child: Column(
+                      children: [
+                        const SizedBox(height: 16),
+                        CircleAvatar(
+                          radius: 36,
+                          backgroundColor: _accent,
+                          child: Text(
+                            initials,
+                            style: const TextStyle(
+                              color: Colors.white,
+                              fontSize: 22,
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
+                        ),
+                        const SizedBox(height: 12),
+                        Text(
+                          name,
                           style: const TextStyle(
-                            color: Colors.white,
-                            fontSize: 22,
+                            color: _primary,
+                            fontSize: 20,
                             fontWeight: FontWeight.w600,
                           ),
                         ),
-                      ),
-                      const SizedBox(height: 12),
-                      Text(name,
-                          style: const TextStyle(
-                              color: _primary,
-                              fontSize: 20,
-                              fontWeight: FontWeight.w600)),
-                      const SizedBox(height: 4),
-                      Text(email,
-                          style: const TextStyle(color: _muted, fontSize: 13)),
-                      const SizedBox(height: 28),
-                    ]),
+                        if (username.isNotEmpty) ...[
+                          const SizedBox(height: 4),
+                          Text(
+                            '@$username',
+                            style: const TextStyle(color: _muted, fontSize: 13),
+                          ),
+                        ],
+                        const SizedBox(height: 4),
+                        Text(
+                          email,
+                          style: const TextStyle(color: _muted, fontSize: 13),
+                        ),
+                        const SizedBox(height: 28),
+                      ],
+                    ),
                   ),
 
                   _sectionLabel('Social'),
@@ -75,11 +95,15 @@ class ProfileScreen extends StatelessWidget {
                     _menuRow(
                       context,
                       icon: Icons.people_outline,
-	                      iconBg: _accent.withValues(alpha: 0.15),
+                      iconBg: _accent.withValues(alpha: 0.15),
                       iconColor: _accent,
                       label: 'Friends',
-                      onTap: () => Navigator.push(context,
-                          MaterialPageRoute(builder: (_) => const FriendsScreen())),
+                      onTap: () => Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) => const FriendsScreen(),
+                        ),
+                      ),
                     ),
                   ]),
 
@@ -90,11 +114,15 @@ class ProfileScreen extends StatelessWidget {
                     _menuRow(
                       context,
                       icon: Icons.settings_outlined,
-	                      iconBg: Colors.white.withValues(alpha: 0.06),
+                      iconBg: Colors.white.withValues(alpha: 0.06),
                       iconColor: _muted,
                       label: 'Settings',
-                      onTap: () => Navigator.push(context,
-                          MaterialPageRoute(builder: (_) => const SettingsScreen())),
+                      onTap: () => Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) => const SettingsScreen(),
+                        ),
+                      ),
                     ),
                   ]),
 
@@ -112,8 +140,10 @@ class ProfileScreen extends StatelessWidget {
                         ),
                       ),
                       onPressed: () => _logout(context),
-                      child: const Text('Log Out',
-                          style: TextStyle(fontWeight: FontWeight.w500)),
+                      child: const Text(
+                        'Log Out',
+                        style: TextStyle(fontWeight: FontWeight.w500),
+                      ),
                     ),
                   ),
                 ],
@@ -126,23 +156,26 @@ class ProfileScreen extends StatelessWidget {
   } // end build
 
   Widget _sectionLabel(String label) => Padding(
-        padding: const EdgeInsets.only(bottom: 8),
-        child: Text(label.toUpperCase(),
-            style: const TextStyle(
-                color: Color(0x40FFFFFF),
-                fontSize: 11,
-                fontWeight: FontWeight.w600,
-                letterSpacing: 0.8)),
-      );
+    padding: const EdgeInsets.only(bottom: 8),
+    child: Text(
+      label.toUpperCase(),
+      style: const TextStyle(
+        color: Color(0x40FFFFFF),
+        fontSize: 11,
+        fontWeight: FontWeight.w600,
+        letterSpacing: 0.8,
+      ),
+    ),
+  );
 
   Widget _menuCard(List<Widget> rows) => Container(
-        decoration: BoxDecoration(
-          color: _card,
-          borderRadius: BorderRadius.circular(16),
-          border: Border.all(color: _divider),
-        ),
-        child: Column(children: rows),
-      );
+    decoration: BoxDecoration(
+      color: _card,
+      borderRadius: BorderRadius.circular(16),
+      border: Border.all(color: _divider),
+    ),
+    child: Column(children: rows),
+  );
 
   Widget _menuRow(
     BuildContext context, {
@@ -151,29 +184,34 @@ class ProfileScreen extends StatelessWidget {
     required Color iconColor,
     required String label,
     required VoidCallback onTap,
-  }) =>
-      InkWell(
-        onTap: onTap,
-        borderRadius: BorderRadius.circular(16),
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
-          child: Row(children: [
-            Container(
-              width: 32,
-              height: 32,
-              decoration: BoxDecoration(
-                  color: iconBg, borderRadius: BorderRadius.circular(8)),
-              child: Icon(icon, color: iconColor, size: 17),
+  }) => InkWell(
+    onTap: onTap,
+    borderRadius: BorderRadius.circular(16),
+    child: Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+      child: Row(
+        children: [
+          Container(
+            width: 32,
+            height: 32,
+            decoration: BoxDecoration(
+              color: iconBg,
+              borderRadius: BorderRadius.circular(8),
             ),
-            const SizedBox(width: 12),
-            Expanded(
-              child: Text(label,
-                  style: const TextStyle(color: Colors.white, fontSize: 14)),
+            child: Icon(icon, color: iconColor, size: 17),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Text(
+              label,
+              style: const TextStyle(color: Colors.white, fontSize: 14),
             ),
-            const Icon(Icons.chevron_right, color: Color(0x30FFFFFF), size: 18),
-          ]),
-        ),
-      );
+          ),
+          const Icon(Icons.chevron_right, color: Color(0x30FFFFFF), size: 18),
+        ],
+      ),
+    ),
+  );
 
   Future<void> _logout(BuildContext context) async {
     await AuthServices().signOut();

--- a/focusfeed/lib/features/settings/settings_screen.dart
+++ b/focusfeed/lib/features/settings/settings_screen.dart
@@ -23,6 +23,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
   bool _isLoading = true;
 
   // Account fields
+  String displayName = "";
   String username = "";
   String email = "";
   String school = "";
@@ -53,8 +54,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
       final firebaseUser = FirebaseAuth.instance.currentUser;
       if (!mounted) return;
       setState(() {
-        username =
+        displayName =
             data?['displayName'] as String? ?? firebaseUser?.displayName ?? '';
+        username = data?['username'] as String? ?? '';
         email = data?['email'] as String? ?? firebaseUser?.email ?? '';
         school = data?['school'] as String? ?? '';
         selectedCourses = List<String>.from(
@@ -127,9 +129,25 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 ),
                 SettingsTile(
                   icon: Icons.person_outline,
+                  title: "Display Name",
+                  subtitle: displayName,
+                  onTap: _openDisplayNameDialog,
+                  cardColor: _card,
+                  textPrimary: _textPrimary,
+                  textSecondary: _textSecondary,
+                ),
+                SettingsTile(
+                  icon: Icons.alternate_email,
                   title: "Username",
-                  subtitle: username,
-                  onTap: _openUsernameDialog,
+                  subtitle: username.isEmpty ? "No username set" : "@$username",
+                  onTap: () {
+                    _showSimpleInfoSheet(
+                      title: "Username",
+                      message: username.isEmpty
+                          ? "No username is set for this account yet."
+                          : "Your username is @$username.",
+                    );
+                  },
                   cardColor: _card,
                   textPrimary: _textPrimary,
                   textSecondary: _textSecondary,
@@ -313,19 +331,19 @@ class _SettingsScreenState extends State<SettingsScreen> {
   /// Updates the display name in both Firebase Auth and Firestore so both
   /// sources stay in sync. Firebase Auth is the source of truth for the
   /// logged-in user object; Firestore is queried by other features.
-  void _openUsernameDialog() {
-    final controller = TextEditingController(text: username);
+  void _openDisplayNameDialog() {
+    final controller = TextEditingController(text: displayName);
 
     showCenteredInputDialog(
       context: context,
-      title: "Change Username",
+      title: "Change Display Name",
       cardColor: _card,
       textPrimary: _textPrimary,
       child: Column(
         children: [
           _themedTextField(
             controller: controller,
-            label: "Username",
+            label: "Display Name",
             icon: Icons.person_outline,
           ),
           const SizedBox(height: 20),
@@ -339,13 +357,16 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 await FirebaseAuth.instance.currentUser?.updateDisplayName(
                   value,
                 );
-                await _profileService.updateProfile({'displayName': value});
+                await _profileService.updateProfile({
+                  'displayName': value,
+                  'displayNameLower': value.toLowerCase(),
+                });
                 if (!mounted) return;
-                setState(() => username = value);
+                setState(() => displayName = value);
                 Navigator.pop(context);
-                _showSnackBar("Username updated");
+                _showSnackBar("Display name updated");
               } catch (_) {
-                _showSnackBar("Failed to update username");
+                _showSnackBar("Failed to update display name");
               }
             },
           ),

--- a/focusfeed/pubspec.lock
+++ b/focusfeed/pubspec.lock
@@ -9,6 +9,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.69"
+  antlr4:
+    dependency: transitive
+    description:
+      name: antlr4
+      sha256: "752b4a6e4ad97953652a2b2bbf5377f46c94b579d3372b50080c7e5858234a05"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.13.2"
   archive:
     dependency: transitive
     description:
@@ -41,6 +49,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
+  cel:
+    dependency: transitive
+    description:
+      name: cel
+      sha256: "51d77e16424d41b5fdb0a239be4c8a0550d4dd3f952801d35375ddd90cfb49da"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.4+1"
   characters:
     dependency: transitive
     description:
@@ -129,6 +145,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.12"
+  equatable:
+    dependency: transitive
+    description:
+      name: equatable
+      sha256: "3e0141505477fd8ad55d6eb4e7776d3fe8430be8e497ccb1521370c3f21a3e2b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.8"
   fake_async:
     dependency: transitive
     description:
@@ -137,6 +161,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.3"
+  fake_cloud_firestore:
+    dependency: "direct dev"
+    description:
+      name: fake_cloud_firestore
+      sha256: "95e01c95f956b31c62cb9fc54b8d51f32f1ae2909e6c0a5ce316da997e83a5c4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.0+1"
+  fake_firebase_security_rules:
+    dependency: transitive
+    description:
+      name: fake_firebase_security_rules
+      sha256: "6af54bedfd6985451a9735f2cfac91ffe0128bfc92bf15e8544cd56c6941d6cc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.4"
   ffi:
     dependency: transitive
     description:
@@ -488,14 +528,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.0"
+  logger:
+    dependency: transitive
+    description:
+      name: logger
+      sha256: "25aee487596a6257655a1e091ec2ae66bc30e7af663592cc3a27e6591e05035c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.7.0"
+  logging:
+    dependency: transitive
+    description:
+      name: logging
+      sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -520,6 +576,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
+  mock_exceptions:
+    dependency: transitive
+    description:
+      name: mock_exceptions
+      sha256: "6e3e623712d2c6106ffe9e14732912522b565ddaa82a8dcee6cd4441b5984056"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.2"
+  more:
+    dependency: transitive
+    description:
+      name: more
+      sha256: e252628d2183cc09539b686abfbd9d8302675959b89a2a8146f5f4baca6ac5ba
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.7.0"
   path:
     dependency: transitive
     description:
@@ -552,6 +624,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.5.0"
+  profanity_filter:
+    dependency: "direct main"
+    description:
+      name: profanity_filter
+      sha256: afe466d42a2763a5b86849192bee3337de45a9566d5915a0fe4aa5f9cd2e8ac4
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
+  rx:
+    dependency: transitive
+    description:
+      name: rx
+      sha256: "7f54bd39cc63a01c770c1de4b6ce8e135eb13119614cba2216bd9a93ccd29e56"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.0"
+  rxdart:
+    dependency: transitive
+    description:
+      name: rxdart
+      sha256: "5c3004a4a8dbb94bd4bf5412a4def4acdaa12e12f269737a5751369e12d1a962"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.28.0"
   sign_in_with_apple:
     dependency: "direct main"
     description:
@@ -625,10 +721,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.9"
+    version: "0.7.10"
   typed_data:
     dependency: transitive
     description:

--- a/focusfeed/pubspec.yaml
+++ b/focusfeed/pubspec.yaml
@@ -21,12 +21,14 @@ dependencies:
   image_picker: ^1.2.1
   google_mlkit_text_recognition: ^0.15.1
   image_cropper: ^12.2.1
+  profanity_filter: ^2.0.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^6.0.0
   flutter_launcher_icons: ^0.14.3
+  fake_cloud_firestore: ^4.1.0+1
 
 flutter_launcher_icons:
   android: true

--- a/focusfeed/test/create_account_screen_test.dart
+++ b/focusfeed/test/create_account_screen_test.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:focusfeed/features/auth/screens/create_account_screen.dart';
+
+void main() {
+  testWidgets('signup form asks for username without name fields', (
+    tester,
+  ) async {
+    await tester.pumpWidget(const MaterialApp(home: CreateAccountScreen()));
+
+    expect(find.text('Create Account'), findsWidgets);
+    expect(find.widgetWithText(TextFormField, 'Username'), findsOneWidget);
+    expect(find.widgetWithText(TextFormField, 'Display Name'), findsNothing);
+    expect(find.widgetWithText(TextFormField, 'Full Name'), findsNothing);
+  });
+}

--- a/focusfeed/test/signup_test.dart
+++ b/focusfeed/test/signup_test.dart
@@ -1,7 +1,70 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:focusfeed/features/auth/services/username_policy.dart';
+import 'package:focusfeed/features/auth/services/username_reservation_service.dart';
+import 'package:profanity_filter/profanity_filter.dart';
 
 void main() {
-  test('signup test placeholder', () {
-    expect(true, true);
+  group('UsernamePolicy', () {
+    test('accepts and normalizes a valid username', () {
+      expect(UsernamePolicy.validate('austyn_15'), isNull);
+      expect(UsernamePolicy.normalize(' Austyn_15 '), 'austyn_15');
+    });
+
+    test('rejects common format problems', () {
+      final invalidUsernames = [
+        '',
+        'short',
+        '1austyn',
+        'austyn!!',
+        'austyn__15',
+        'austyn_',
+        'abcdefghijklmnopqrstu',
+      ];
+
+      for (final username in invalidUsernames) {
+        expect(UsernamePolicy.validate(username), isNotNull);
+      }
+    });
+
+    test('rejects reserved app/account words', () {
+      expect(UsernamePolicy.validate('admin_user'), isNotNull);
+      expect(UsernamePolicy.validate('FocusFeed7'), isNotNull);
+      expect(UsernamePolicy.validate('support_15'), isNotNull);
+    });
+
+    test('rejects profanity through the shared filter package', () {
+      final usernameSafePattern = RegExp(r'^[a-zA-Z][a-zA-Z0-9]{5,19}$');
+      final filteredTerm = ProfanityFilter().wordsToFilterOutList.firstWhere(
+        (term) => usernameSafePattern.hasMatch(term),
+      );
+
+      expect(UsernamePolicy.validate(filteredTerm), isNotNull);
+    });
+  });
+
+  group('UsernameReservationService', () {
+    test(
+      'saves usernames to the reservation bank and rejects repeats',
+      () async {
+        final firestore = FakeFirebaseFirestore();
+        final reservations = UsernameReservationService(firestore: firestore);
+
+        await reservations.reserveUsername(uid: 'user-1', username: 'Austyn15');
+
+        final savedUsername = await firestore
+            .collection('usernames')
+            .doc('austyn15')
+            .get();
+        expect(savedUsername.exists, isTrue);
+        expect(savedUsername.data()?['uid'], 'user-1');
+
+        expect(
+          () =>
+              reservations.reserveUsername(uid: 'user-2', username: 'austyn15'),
+          throwsA(isA<UsernameTakenException>()),
+        );
+      },
+    );
   });
 }


### PR DESCRIPTION
## Task
Task 57

## Summary
- Updated signup to collect username only instead of full/display name
- Added username validation for format, reserved words, and profanity filtering
- Added Firestore username reservation so duplicate usernames cannot be reused
- Added display name editing in settings while showing @username under display names
- Updated friends/profile screens to show display name with @username and realtime profile updates

## Testing
- flutter analyze
- flutter test test/signup_test.dart test/create_account_screen_test.dart
